### PR TITLE
Fixes #80. Separate nilable/non-nilable accessors for associations.

### DIFF
--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -575,7 +575,7 @@ describe Crecto do
         Repo.insert(post)
 
         users = Repo.all(User, Query.where(id: user.id).preload(:posts))
-        users[0].posts.not_nil!.size.should eq(2)
+        users[0].posts.size.should eq(2)
       end
 
       it "should preload the has_many through association" do
@@ -593,8 +593,8 @@ describe Crecto do
 
         users = Repo.all(User, Query.where(id: user.id).preload(:projects))
         user = users[0]
-        user.user_projects.not_nil!.size.should eq 1
-        user.projects.not_nil!.size.should eq 1
+        user.user_projects.size.should eq 1
+        user.projects.size.should eq 1
       end
 
       it "shoud not preload if there are no 'through' associated records" do
@@ -603,7 +603,11 @@ describe Crecto do
         user = Repo.insert(user).instance
 
         users = Repo.all(User, Query.where(id: user.id).preload(:projects))
-        users[0].projects.should eq(nil)
+
+        expect_raises(Crecto::AssociationNotLoaded) do
+          users[0].projects
+        end
+        users[0].projects?.should eq(nil)
       end
 
       it "should preload the belongs_to association" do
@@ -616,7 +620,7 @@ describe Crecto do
         post = Repo.insert(post).instance
 
         posts = Repo.all(Post, Query.where(id: post.id).preload(:user))
-        posts[0].user.as(User).id.should eq(user.id)
+        posts[0].user.id.should eq(user.id)
       end
 
       it "should set the foreign key when setting the object" do

--- a/spec/schema_spec.cr
+++ b/spec/schema_spec.cr
@@ -48,6 +48,51 @@ describe Crecto do
       end
     end
 
+    describe "#belongs_to" do
+      it "should define a nilable accessor for the association" do
+        post = Post.new
+        post.user?.should eq(nil)
+      end
+
+      it "should define a non-nilable accessor for the association" do
+        post = Post.new
+        user = User.new
+        post.user = user
+        post.user.should eq(user)
+        typeof(post.user).should eq(User)
+      end
+    end
+
+    describe "#has_one" do
+      it "should define a nilable accessor for the association" do
+        user = User.new
+        user.post?.should eq(nil)
+      end
+
+      it "should define a non-nilable accessor for the association" do
+        user = User.new
+        post = Post.new
+        user.post = post
+        user.post.should eq(post)
+        typeof(user.post).should eq(Post)
+      end
+    end
+
+    describe "#has_many" do
+      it "should define a nilable accessor for the association" do
+        user = User.new
+        user.posts?.should eq(nil)
+      end
+
+      it "should define a non-nilable accessor for the association" do
+        user = User.new
+        post = Post.new
+        user.posts = [post]
+        user.posts.should eq([post])
+        typeof(user.posts).should eq(Array(Post))
+      end
+    end
+
     describe "#to_query_hash" do
       it "should build the correct hash from the object" do
         u = User.new
@@ -56,7 +101,7 @@ describe Crecto do
         u.stuff = 2343 # virtual, shouldn't be in query hash
         u.nope = 34.9900
         u.pageviews = 1234567890
-        
+
         u.to_query_hash.should eq({:name => "tester", :things => 6644, :smallnum => nil, :nope => 34.99, :yep => nil, :some_date => nil, :pageviews => 1234567890, :created_at => nil, :updated_at => nil})
       end
     end

--- a/src/crecto/errors/association_not_loaded.cr
+++ b/src/crecto/errors/association_not_loaded.cr
@@ -1,0 +1,5 @@
+module Crecto
+  # :nodoc:
+  class AssociationNotLoaded < Exception
+  end
+end

--- a/src/crecto/schema/belongs_to.cr
+++ b/src/crecto/schema/belongs_to.cr
@@ -5,7 +5,16 @@ module Crecto
       VALID_BELONGS_TO_OPTIONS = [:foreign_key]
 
       macro belongs_to(association_name, klass, **opts)
-        property {{association_name.id}} : {{klass}}?
+        @{{association_name.id}} : {{klass}}?
+
+        def {{association_name.id}}? : {{klass}}?
+          @{{association_name.id}}
+        end
+
+        def {{association_name.id}} : {{klass}}
+          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' not loaded")
+        end
+
 
         {%
           foreign_key = klass.id.stringify.underscore.downcase + "_id"

--- a/src/crecto/schema/has_many.cr
+++ b/src/crecto/schema/has_many.cr
@@ -2,8 +2,20 @@ module Crecto
   module Schema
     module HasMany
       macro has_many(association_name, klass, **opts)
+        @{{association_name.id}} : Array({{klass}})?
 
-        property {{association_name.id}} : Array({{klass}})?
+        def {{association_name.id}}? : Array({{klass}})?
+          @{{association_name.id}}
+        end
+
+        def {{association_name.id}} : Array({{klass}})
+          @{{association_name.id}} || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' not loaded")
+        end
+
+        def {{association_name.id}}=(val : Array({{klass}}))
+          @{{association_name.id}} = val
+        end
+
 
         {%
           through = opts[:through] || nil

--- a/src/crecto/schema/has_one.cr
+++ b/src/crecto/schema/has_one.cr
@@ -5,7 +5,16 @@ module Crecto
       VALID_HAS_ONE_OPTIONS = [:foreign_key]
 
       macro has_one(association_name, klass, **opts)
-        property {{association_name.id}} : {{klass}}?
+        @{{association_name.id}} : {{klass}}?
+
+        def {{association_name.id}}? : {{klass}}?
+          @{{association_name.id}}
+        end
+
+        def {{association_name.id}} : {{klass}}
+          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' not loaded")
+        end
+
 
         {%
           foreign_key = @type.id.stringify.underscore.downcase + "_id"
@@ -25,6 +34,13 @@ module Crecto
         {% if on_replace && on_replace == :nullify %}
           self.add_nullify_association({{association_name.id.symbolize}})
         {% end %}
+
+        def {{association_name.id}}=(val : {{klass}}?)
+          @{{association_name.id}} = val
+          return if val.nil?
+          @{{foreign_key.id}} = val.pkey_value.as(PkeyValue)
+        end
+
 
         ASSOCIATIONS.push({
           association_type: :has_one,


### PR DESCRIPTION
Associations now implement a nilable accessor (`thing?`), as well as a non-nilable one (`thing`). If an association has not been preloaded (or it has been explicitly set to nil), `thing?` will return nil, while `thing` will raise a `Crecto::AssociationNotLoaded`. This seems to be a convention in Crystal, as seen in the standard library with things like `Array#first?` and `Array#first`.

Having these alternatives should simplify usage of associations, particularly `has_many`:

```crystal
users = Repo.all(User, Query.new, preload: [:posts])
user = users[0]

# before
user.posts.not_nil!.each{ } # Fails if `posts` is not loaded
user.posts.as(Array(Post)).each{ } # Fails if `posts` is not loaded
user.posts.not_nil!.each{ } unless user.posts.nil? # Always works, but verbose

# after
user.posts.each{ } # raises Crecto::AssociationNotLoaded if `:posts` is not preloaded
user.posts.each{ } if user.posts? # Always works
```