### PR TITLE
Fix `Repo.get` for associations.

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -166,14 +166,12 @@ end
 
 class Post < Crecto::Model
   schema "posts" do
-    field :user_id, Int32
     belongs_to :user, User
   end
 end
 
 class Thing < Crecto::Model
   schema "things" do
-    field :user_different_defaults_id, PkeyValue
     belongs_to :user, UserDifferentDefaults, foreign_key: :user_different_defaults_id
   end
 end

--- a/src/crecto/schema/belongs_to.cr
+++ b/src/crecto/schema/belongs_to.cr
@@ -18,14 +18,11 @@ module Crecto
 
         {%
           foreign_key = klass.id.stringify.underscore.downcase + "_id"
-
-          if opts[:foreign_key]
-            foreign_key = opts[:foreign_key]
-          end
+          foreign_key = opts[:foreign_key] if opts[:foreign_key]
         %}
 
         {% unless FIELDS.select{|f| f[:name] == foreign_key.id.symbolize}.size > 0 %}
-          field :{{foreign_key.id}}, PkeyValue
+          field {{foreign_key.id.symbolize}}, PkeyValue
         {% end %}
 
         def {{association_name.id}}=(val : {{klass}}?)

--- a/src/crecto/schema/has_many.cr
+++ b/src/crecto/schema/has_many.cr
@@ -20,10 +20,7 @@ module Crecto
         {%
           through = opts[:through] || nil
           foreign_key = @type.id.stringify.underscore.downcase + "_id"
-
-          if opts[:foreign_key]
-            foreign_key = opts[:foreign_key]
-          end
+          foreign_key = opts[:foreign_key] if opts[:foreign_key]
         %}
 
         {% on_replace = opts[:dependent] || opts[:on_replace] %}

--- a/src/crecto/schema/has_one.cr
+++ b/src/crecto/schema/has_one.cr
@@ -18,10 +18,7 @@ module Crecto
 
         {%
           foreign_key = @type.id.stringify.underscore.downcase + "_id"
-
-          if opts[:foreign_key]
-            foreign_key = opts[:foreign_key]
-          end
+          foreign_key = opts[:foreign_key] if opts[:foreign_key]
         %}
 
         {% on_replace = opts[:dependent] || opts[:on_replace] %}


### PR DESCRIPTION
Using `Repo.get` with an instance and an association name was treating `belongs_to` associations as if they were `has_many`s, meaning it was trying to find the queryable's `foreign_key` on the association's table, leading to things like this:

```
user = Repo.get(post, :user)
```

where the query is asking for `users.user_id`, instead of `users.id` with the _value_ of `user_id` from `post`.

This PR adds the private method `Repo.get_association` to deal with each different type of association properly. With this, not only are `belongs_to` associations loading properly, but `has_many`s and `has_one`s are also supported through `Repo.get`:

```
posts = Repo.get(user, :posts)
posts.is_a?(Array(Post)) # => true
```