### PR TITLE
Always set `has_many` association values, better errors for nilable associations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ class User < Crecto::Model
 end
 
 class Post < Crecto::Model
-  
+
   schema "posts" do
     belongs_to :user, User
   end
@@ -219,11 +219,30 @@ posts = Repo.all(user, :posts)
 #
 # Preload associations
 #
-users = Repo.all(User, Query.new, preload: [:posts])
+users = Repo.all(User, preload: [:posts])
 users[0].posts # has_many relation is preloaded
 
-posts = Repo.all(Post, Query.new, preload: [:user])
+posts = Repo.all(Post, preload: [:user])
 posts[0].user # belongs_to relation preloaded
+
+#
+# Nil-check associations
+#
+users = Repo.all(User)
+users[0].posts? # => nil
+users[0].posts  # raises Crecto::AssociationNotLoaded
+
+# For has_many associations, the result will always be an array.
+users = Repo.all(User, preload: [:posts])
+users[0].posts? # => Array(Post)
+users[0].posts  # => Array(Post)
+
+# For belongs_to and has_one, the result may still be nil if no record exists.
+# If the association is nullable, always use `association?`.
+post = Repo.insert(Post.new).instance
+posts = Repo.get(Post, post.id, preload: [:user])
+posts[0].user? # nil
+posts[0].user  # raises Crecto::AssociationNotLoaded
 
 #
 # Aggregate functions

--- a/README.md
+++ b/README.md
@@ -228,21 +228,22 @@ posts[0].user # belongs_to relation preloaded
 #
 # Nil-check associations
 #
+# If an association is not loaded, the normal accessor will raise an error.
 users = Repo.all(User)
 users[0].posts? # => nil
 users[0].posts  # raises Crecto::AssociationNotLoaded
 
-# For has_many associations, the result will always be an array.
+# For has_many preloads, the result will always be an array.
 users = Repo.all(User, preload: [:posts])
 users[0].posts? # => Array(Post)
 users[0].posts  # => Array(Post)
 
-# For belongs_to and has_one, the result may still be nil if no record exists.
-# If the association is nullable, always use `association?`.
+# For belongs_to and has_one preloads, the result may still be nil if no
+# record exists. If the association is nullable, always use `association?`.
 post = Repo.insert(Post.new).instance
-posts = Repo.get(Post, post.id, preload: [:user])
-posts[0].user? # nil
-posts[0].user  # raises Crecto::AssociationNotLoaded
+post = Repo.get(Post, post.id, preload: [:user])
+post.user? # nil
+post.user  # raises Crecto::AssociationNotLoaded
 
 #
 # Aggregate functions

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -478,8 +478,8 @@ module Crecto
     private def has_one_preload(results, queryable, preload)
       query = Crecto::Repo::Query.where(queryable.foreign_key_for_association(preload), results[0].pkey_value)
       relation_item = all(queryable.klass_for_association(preload), query)
-      unless relation_item.nil? || relation_item.empty?
-        queryable.set_value_for_association(preload, results[0], relation_item[0])
+      if relation_item.first?
+        queryable.set_value_for_association(preload, results[0], relation_item.first)
       end
     end
 
@@ -495,15 +495,11 @@ module Crecto
       ids = results.map(&.pkey_value.as(PkeyValue))
       query = Crecto::Repo::Query.where(queryable.foreign_key_for_association(preload), ids)
       relation_items = all(queryable.klass_for_association(preload), query)
-      unless relation_items.nil?
-        relation_items = relation_items.group_by { |t| queryable.foreign_key_value_for_association(preload, t) }
+      relation_items = relation_items.group_by { |t| queryable.foreign_key_value_for_association(preload, t) }
 
-        results.each do |result|
-          if relation_items.has_key?(result.pkey_value)
-            items = relation_items[result.pkey_value]
-            queryable.set_value_for_association(preload, result, items.map { |i| i.as(Crecto::Model) })
-          end
-        end
+      results.each do |result|
+        items = relation_items[result.pkey_value]? || [] of Crecto::Model
+        queryable.set_value_for_association(preload, result, items.map { |i| i.as(Crecto::Model) })
       end
     end
 
@@ -512,31 +508,22 @@ module Crecto
       join_query = Crecto::Repo::Query.where(queryable.foreign_key_for_association(preload), ids)
       # UserProjects
       join_table_items = all(queryable.klass_for_association(queryable.through_key_for_association(preload).as(Symbol)), join_query)
-      unless join_table_items.nil? || join_table_items.empty?
-        # array of Project id's
-        join_ids = join_table_items.map { |i| queryable.klass_for_association(preload).foreign_key_value_for_association(queryable.through_key_for_association(preload).as(Symbol), i) }
-        association_query = Crecto::Repo::Query.where(queryable.klass_for_association(preload).primary_key_field_symbol, join_ids)
-        # Projects
-        relation_items = all(queryable.klass_for_association(preload), association_query)
 
-        # UserProject grouped by user_id
-        join_table_items = join_table_items.group_by { |t| queryable.foreign_key_value_for_association(queryable.through_key_for_association(preload).as(Symbol), t) }
+      # array of Project id's
+      join_ids = join_table_items.map { |i| queryable.klass_for_association(preload).foreign_key_value_for_association(queryable.through_key_for_association(preload).as(Symbol), i) }
+      association_query = Crecto::Repo::Query.where(queryable.klass_for_association(preload).primary_key_field_symbol, join_ids)
+      # Projects
+      relation_items = all(queryable.klass_for_association(preload), association_query)
+      # UserProject grouped by user_id
+      join_table_items = join_table_items.group_by { |t| queryable.foreign_key_value_for_association(queryable.through_key_for_association(preload).as(Symbol), t) }
 
-        results.each do |result|
-          if join_table_items.has_key?(result.pkey_value)
-            join_items = join_table_items[result.pkey_value]
-
-            # set join table has_many assocation i.e. user.user_projects
-            queryable.set_value_for_association(queryable.through_key_for_association(preload).as(Symbol), result, join_items.map { |i| i.as(Crecto::Model) })
-
-            unless relation_items.nil?
-              queryable_relation_items = relation_items.select { |i| join_ids.includes?(i.pkey_value) }
-
-              # set association i.e. user.projects
-              queryable.set_value_for_association(preload, result, queryable_relation_items.map { |i| i.as(Crecto::Model) })
-            end
-          end
-        end
+      results.each do |result|
+        join_items = join_table_items[result.pkey_value]? || [] of Crecto::Model
+        # set join table has_many assocation i.e. user.user_projects
+        queryable.set_value_for_association(queryable.through_key_for_association(preload).as(Symbol), result, join_items.map { |i| i.as(Crecto::Model) })
+        queryable_relation_items = relation_items.select { |i| join_ids.includes?(i.pkey_value) }
+        # set association i.e. user.projects
+        queryable.set_value_for_association(preload, result, queryable_relation_items.map { |i| i.as(Crecto::Model) })
       end
     end
 

--- a/src/crecto/schema/belongs_to.cr
+++ b/src/crecto/schema/belongs_to.cr
@@ -12,7 +12,7 @@ module Crecto
         end
 
         def {{association_name.id}} : {{klass}}
-          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' not loaded")
+          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' is not loaded or is nil. Use `{{association_name.id}}?' if the association is nilable.")
         end
 
 

--- a/src/crecto/schema/has_one.cr
+++ b/src/crecto/schema/has_one.cr
@@ -12,7 +12,7 @@ module Crecto
         end
 
         def {{association_name.id}} : {{klass}}
-          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' not loaded")
+          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' is not loaded or is nil. Use `{{association_name.id}}?' if the association is nilable.")
         end
 
 


### PR DESCRIPTION
For `has_many` and `has_many, through` associations, results with no associated records will now default to `[] of Array(Crecto::Model)` instead of nil. This should ensure that the relationships are never nil, and that the normal accessor (e.g. `user.posts`) will always be an array, and will only raise an error if the association has not been loaded. In other words, this will always work:

```crystal
user = Repo.all(User).first
user.posts # => raises Crecto::AssociationNotLoaded
user = Repo.all(User, preload: [:posts])
user.posts # => always an array, even if it has no entries
```

For nilable `belongs_to` and `has_one` associations, there is no good way to tell if the association is purposefully nil or simply has not been loaded yet.

To help users with nilable associations, the error that gets raised now suggests to use the nilable accessor instead:

```crystal
post = Post.new
post.user_id = nil
post = Repo.insert(post).instance

post = Repo.get(Post, post.id, preload: [:user])
post.user? # => nil
post.user  # raises "Association `user' is not loaded or is nil. Use `user?' if the association is nilable."
```

This PR also updates the README accordingly.