### PR TITLE
Make `get_association` public

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,10 @@ changeset = Repo.delete(user)
 #
 
 user = Repo.get(User, id).as(User)
-posts = Repo.all(user, :posts)
+posts = Repo.get_association(user, :posts)
+
+post = Repo.get(Post, id).as(Post)
+user = Repo.get_association(post, :user)
 
 #
 # Preload associations


### PR DESCRIPTION
`Repo.all)` and `Repo.get` for associations have been removed in favor of making `Repo.get_association` a public method.

Spawned by: https://github.com/Crecto/crecto/pull/87#issuecomment-302892093