### PR TITLE
Update Postgres port in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ module Repo
     conf.hostname = "localhost"
     conf.username = "user"
     conf.password = "password"
-    conf.port = 5342
+    conf.port = 5432
     # you can also set initial_pool_size, max_pool_size, max_idle_pool_size,
     #  checkout_timeout, retry_attempts, and retry_delay
   end


### PR DESCRIPTION
I had trouble connecting to Postgres when I first setup crecto. After more time debugging than I care to admit, I realized the port was wrong in the sample config.

Here's a tiny PR to fix that 🙂 .