### PR TITLE
fix WHERE IN query with empty Array

### DIFF
--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -77,6 +77,18 @@ describe Crecto do
 
         users = Repo.all(User, query)
         users.size.should be > 0
+
+        query = Query
+          .where(:name, [] of String)
+
+        users = Repo.all(User, query)
+        users.size.should eq 0
+
+        query = Query
+          .where(name: [] of String)
+
+        users = Repo.all(User, query)
+        users.size.should eq 0
       end
 
       it "should allow IS NULL queries" do

--- a/src/crecto/adapters/base_adapter.cr
+++ b/src/crecto/adapters/base_adapter.cr
@@ -224,7 +224,11 @@ module Crecto
 
           results = " #{queryable.table_name}.#{key.to_s}"
           results += if where[key].is_a?(Array)
-                       " IN (" + where[key].as(Array).uniq.map { |p| "?" }.join(", ") + ")"
+                       if where[key].as(Array).size === 0
+                         next " 1=0"
+                       else
+                         " IN (" + where[key].as(Array).uniq.map { |p| "?" }.join(", ") + ")"
+                       end
                      elsif where[key].is_a?(Nil)
                        " IS NULL"
                      else


### PR DESCRIPTION

Invalid SQL query is generated when WHERE value array is empty.

```crystal
query = Query
  .where(name: [] of String)

users = Repo.all(User, query)
users.size.should eq 0
```

```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1
0x10432de95: *CallStack::unwind:Array(Pointer(Void)) at ??
0x10432de31: *CallStack#initialize:Array(Pointer(Void)) at ??
0x10432de08: *CallStack::new:CallStack at ??
0x1042f42c1: *raise<Exception>:NoReturn at ??
0x1042f42a1: *raise<String>:NoReturn at ??
0x104966685: *MySql::Connection#handle_err_packet<MySql::ReadPacket>:NoReturn at ??
0x104966a6d: *MySql::Connection#raise_if_err_packet<MySql::ReadPacket>:UInt8 at ??
0x10499b70a: *MySql::Statement#initialize<MySql::Connection, String>:(UInt8 | Nil) at ??
0x10499b535: *MySql::Statement::new<MySql::Connection, String>:MySql::Statement at ??
0x104966a29: *MySql::Connection#build_prepared_statement<String>:MySql::Statement at ??
0x1049959d1: *DB::Connection+@DB::Connection#fetch_or_build_prepared_statement<String>:DB::Statement+ at ??
```

For empty array,
it will generate query string like below (like active_record)
```
SELECT users.* FROM users WHERE  1=0
```
