### PR TITLE
Add single quote around primary key fields for update and delete queries

### DIFF
--- a/spec/adapters/mysql_adapter_spec.cr
+++ b/spec/adapters/mysql_adapter_spec.cr
@@ -78,8 +78,8 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
       Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq([
-          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, created_at=?, updated_at=?, id=? WHERE id=#{changeset.instance.id}",
-          "SELECT * FROM users WHERE id = #{changeset.instance.id}",
+          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, created_at=?, updated_at=?, id=? WHERE id='#{changeset.instance.id}'",
+          "SELECT * FROM users WHERE id = '#{changeset.instance.id}'",
         ])
       end
     end
@@ -92,7 +92,7 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
         sql.should eq(
           ["DELETE FROM addresses WHERE  addresses.user_id=?",
            "SELECT user_projects.project_id FROM user_projects WHERE  user_projects.user_id=?",
-           "SELECT * FROM users WHERE id=#{changeset.instance.id}"])
+           "SELECT * FROM users WHERE id='#{changeset.instance.id}'"])
       end
     end
 

--- a/spec/adapters/postgres_adapter_spec.cr
+++ b/spec/adapters/postgres_adapter_spec.cr
@@ -70,7 +70,7 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
       Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq(["UPDATE users SET (name, things, smallnum, nope, yep, some_date, pageviews, created_at, updated_at, id) = \
-          ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) WHERE id=#{changeset.instance.id} RETURNING *"])
+          ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) WHERE id='#{changeset.instance.id}' RETURNING *"])
       end
     end
 
@@ -82,7 +82,7 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
         sql.should eq(
           ["DELETE FROM addresses WHERE  addresses.user_id=$1",
            "SELECT user_projects.project_id FROM user_projects WHERE  user_projects.user_id=$1",
-           "DELETE FROM users WHERE id=#{changeset.instance.id} RETURNING *"])
+           "DELETE FROM users WHERE id='#{changeset.instance.id}' RETURNING *"])
       end
     end
 

--- a/spec/adapters/sqlite3_adapter_spec.cr
+++ b/spec/adapters/sqlite3_adapter_spec.cr
@@ -78,8 +78,8 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
       Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq([
-          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, created_at=?, updated_at=?, id=? WHERE id=#{changeset.instance.id}",
-          "SELECT * FROM users WHERE id = #{changeset.instance.id}",
+          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, created_at=?, updated_at=?, id=? WHERE id='#{changeset.instance.id}'",
+          "SELECT * FROM users WHERE id = '#{changeset.instance.id}'",
         ])
       end
     end
@@ -92,7 +92,7 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
         sql.should eq(
           ["DELETE FROM addresses WHERE  addresses.user_id=?",
            "SELECT user_projects.project_id FROM user_projects WHERE  user_projects.user_id=?",
-           "SELECT * FROM users WHERE id=#{changeset.instance.id}"])
+           "SELECT * FROM users WHERE id='#{changeset.instance.id}'"])
       end
     end
 

--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -1082,6 +1082,30 @@ describe Crecto do
         changeset.errors.any?.should eq false
         changeset.instance.uuid.should eq id
       end
+
+      it "should update a user with a generated id" do
+        id = SecureRandom.uuid
+        user = UserUUID.new
+        user.name = "test"
+        user.uuid = id
+        user = Repo.insert(user).instance
+
+        user.name = "fred"
+        changeset = Repo.update(user)
+        changeset.errors.any?.should eq false
+        changeset.instance.name.should eq "fred"
+      end
+
+      it "should delete a user with a generated id" do
+        id = SecureRandom.uuid
+        user = UserUUID.new
+        user.name = "test"
+        user.uuid = id
+        user = Repo.insert(user).instance
+
+        changeset = Repo.delete(user)
+        changeset.errors.any?.should eq false
+      end
     end
   end
 end

--- a/src/crecto/adapters/base_adapter.cr
+++ b/src/crecto/adapters/base_adapter.cr
@@ -171,7 +171,7 @@ module Crecto
       private def delete(conn, changeset)
         q = delete_begin(changeset.instance.class.table_name)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}"
+        q.push "#{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'"
         q.push "RETURNING *" if conn.is_a?(DB::Database)
 
         exec_execute(conn, q.join(" "))

--- a/src/crecto/adapters/mysql_adapter.cr
+++ b/src/crecto/adapters/mysql_adapter.cr
@@ -67,21 +67,21 @@ module Crecto
 
         q = update_begin(changeset.instance.class.table_name, fields_values)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}"
+        q.push "#{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'"
 
         exec_execute(conn, q.join(" "), fields_values[:values])
-        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field} = #{changeset.instance.pkey_value}")
+        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field} = '#{changeset.instance.pkey_value}'")
       end
 
       private def self.delete(conn, changeset)
         q = delete_begin(changeset.instance.class.table_name)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}"
+        q.push "#{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'"
 
         if conn.is_a?(DB::TopLevelTransaction)
           exec_execute(conn, q.join(" "))
         else
-          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}")
+          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'")
           exec_execute(conn, q.join(" "))
           sel
         end

--- a/src/crecto/adapters/postgres_adapter.cr
+++ b/src/crecto/adapters/postgres_adapter.cr
@@ -20,7 +20,7 @@ module Crecto
 
         q = update_begin(changeset.instance.class.table_name, fields_values)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}"
+        q.push "#{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'"
         q.push "RETURNING *"
 
         execute(conn, position_args(q.join(" ")), fields_values[:values])

--- a/src/crecto/adapters/sqlite3_adapter.cr
+++ b/src/crecto/adapters/sqlite3_adapter.cr
@@ -66,21 +66,21 @@ module Crecto
 
         q = update_begin(changeset.instance.class.table_name, fields_values)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}"
+        q.push "#{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'"
 
         exec_execute(conn, q.join(" "), fields_values[:values])
-        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field} = #{changeset.instance.pkey_value}")
+        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field} = '#{changeset.instance.pkey_value}'")
       end
 
       private def self.delete(conn, changeset)
         q = delete_begin(changeset.instance.class.table_name)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}"
+        q.push "#{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'"
 
         if conn.is_a?(DB::TopLevelTransaction)
           exec_execute(conn, q.join(" "))
         else
-          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}=#{changeset.instance.pkey_value}")
+          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}='#{changeset.instance.pkey_value}'")
           exec_execute(conn, q.join(" "))
           sel
         end


### PR DESCRIPTION
@iambudi

Previously records with string primary keys were failing on delete and update, this fixes that.