### PR TITLE
fix delete connection leak

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ development_dependencies:
 
   pg:
     github: will/crystal-pg
-    version: 0.13.3
+    version: 0.13.4
 
   sqlite3:
     github: Zhomart/crystal-sqlite3

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -277,7 +277,7 @@ module Crecto
 
       if query.nil?
         changeset.add_error("delete_error", "Delete Failed")
-      elsif tx.nil?
+      elsif tx.nil? && config.adapter == Crecto::Adapters::Postgres # patch for bug in crystal-pg
         query.as(DB::ResultSet).close
       end
 

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -277,6 +277,8 @@ module Crecto
 
       if query.nil?
         changeset.add_error("delete_error", "Delete Failed")
+      elsif tx.nil?
+        query.as(DB::ResultSet).close
       end
 
       changeset.action = :delete


### PR DESCRIPTION
closes #114 

@vladfaust I think this should fix the delete connection leak.  Only closing the result set if not in a transaction, thats why the specs were failing.

Updating to crystal-pg 0.13.4 fixes some other issues as well 👍 