### PR TITLE
raw adapter queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 * added `default` option to fields to set a default value
+* added `raw_query`, `raw_exec`, and `raw_scalar` to Repo to run queries directly on adapter connection
 
 ## [0.7.1] 2017-10-22
 * fixed bug introduced in 0.7.0 for users not using postgres

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -13,6 +13,38 @@ module Crecto
       @@config
     end
 
+    # Run a raw `exec` query directly on the adapter connection
+    def raw_exec(args : Array)
+      config.get_connection.exec(args)
+    end
+
+    # Run a raw `exec` query directly on the adapter connection
+    def raw_exec(*args)
+      config.get_connection.exec(*args)
+    end
+
+    # Run a raw `query` query directly on the adapter connection
+    def raw_query(query, *args)
+      config.get_connection.query(query, *args) do |rs|
+        yield rs
+      end
+    end
+
+    # Run a raw `query` query directly on the adapter connection
+    def raw_query(query, args : Array)
+      config.get_connection.query(args)
+    end
+
+    # Run a raw `query` query directly on the adapter connection
+    def raw_query(query, *args)
+      config.get_connection.query(*args)
+    end
+
+    # Run a raw `scalar` query directly on the adapter connection
+    def raw_scalar(*args)
+      config.get_connection.scalar(*args)
+    end
+
     # Return a list of *queryable* instances using *query*
     #
     # ```


### PR DESCRIPTION
Added `raw_query`, `raw_exec`, and `raw_scalar` to Repo to run queries directly on adapter connection