### PR TITLE
validate virtual attributes

### DIFF
--- a/spec/schema_spec.cr
+++ b/spec/schema_spec.cr
@@ -171,6 +171,17 @@ describe Crecto do
 
         u.to_query_hash.should eq({:name => "tester", :things => 6644, :smallnum => nil, :nope => 34.99, :yep => nil, :some_date => nil, :pageviews => 1234567890, :unique_field => nil, :created_at => nil, :updated_at => nil})
       end
+
+      it "should return virtual attributes if `include_virtual` is passed as true" do
+        u = User.new
+        u.name = "tester"
+        u.things = 6644
+        u.stuff = 2343
+        u.nope = 34.9900
+        u.pageviews = 1234567890
+
+        u.to_query_hash(true).should eq({:name => "tester", :things => 6644, :stuff => 2343, :smallnum => nil, :nope => 34.99, :yep => nil, :some_date => nil, :pageviews => 1234567890, :unique_field => nil, :created_at => nil, :updated_at => nil})
+      end
     end
 
     describe "#pkey_value" do

--- a/src/crecto/changeset/changeset.cr
+++ b/src/crecto/changeset/changeset.cr
@@ -30,7 +30,7 @@ module Crecto
 
       def initialize(@instance : T)
         @class_key = @instance.class.to_s
-        @instance_hash = @instance.to_query_hash
+        @instance_hash = @instance.to_query_hash(true)
         @source = @instance.initial_values
 
         check_required!

--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -220,11 +220,11 @@ module Crecto
 
 
       # Builds a hash from all `CRECTO_FIELDS` defined
-      def to_query_hash
+      def to_query_hash(include_virtual=false)
         query_hash = {} of Symbol => DbValue | ArrayDbValue
 
         {% for field in CRECTO_FIELDS %}
-          if @@changeset_fields.includes?({{field[:name]}})
+          if include_virtual || @@changeset_fields.includes?({{field[:name]}})
             query_hash[{{field[:name]}}] = self.{{field[:name].id}}
             query_hash[{{field[:name]}}] = query_hash[{{field[:name]}}].as(Time).to_utc if query_hash[{{field[:name]}}].is_a?(Time) && query_hash[{{field[:name]}}].as(Time).local?
           end


### PR DESCRIPTION
Previously virtual attributes weren't being validated, this adds validation to virtual attributes.

For example validating the length of a password attribute that doesn't get stored in the database:

```crystal
field :password, String, virtual: true
field :password_confirmation, String, virtual: true

validate_length :password, min: 8
```