### PR TITLE
added fields' cast typed methods

### DIFF
--- a/spec/schema_spec.cr
+++ b/spec/schema_spec.cr
@@ -39,6 +39,10 @@ describe Crecto do
         u.nope.should eq(3.343)
         u.yep.should eq(false)
         u.pageviews.should eq(123451651234)
+
+        u.name!.should eq("fridge")
+        typeof(u.name!).should eq(String)
+        typeof(u.name).should eq((Nil | String))
       end
 
       describe "changing default values" do

--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -44,13 +44,13 @@ module Crecto
     CRECTO_PRIMARY_KEY_FIELD_TYPE = "PkeyValue"
     # :nodoc:
     CRECTO_ASSOCIATIONS = Array(NamedTuple(association_type: Symbol,
-    key: Symbol,
-    this_klass: Model.class,
-    klass: Model.class,
-    foreign_key: Symbol,
-    foreign_key_value: Proc(Model, PkeyValue),
-    set_association: Proc(Model, (Array(Crecto::Model) | Model), Nil),
-    through: Symbol?)).new
+      key: Symbol,
+      this_klass: Model.class,
+      klass: Model.class,
+      foreign_key: Symbol,
+      foreign_key_value: Proc(Model, PkeyValue),
+      set_association: Proc(Model, (Array(Crecto::Model) | Model), Nil),
+      through: Symbol?)).new
 
     # schema block macro
     macro schema(table_name, **opts, &block)
@@ -181,6 +181,13 @@ module Crecto
 
       DB.mapping({ {{mapping.uniq.join(", ").id}} }, false)
       JSON.mapping({ {{mapping.uniq.join(", ").id}} })
+
+      # Builds fields' cast typed method
+      {% for field in CRECTO_FIELDS %}
+        def {{field[:name].id}}!
+          @{{field[:name].id}}.as({{field[:type].id}})
+        end
+      {% end %}
 
       {% for field in json_fields %}
         def {{field.id}}=(val)


### PR DESCRIPTION
I just wanted to add a convenience method to get the field without Nil type:
typeof(user.first_name) = (String | Nil)
typeof(user.first_name!) = String
It could shorten my code:
before: full_name = user.first_name.as(String) + " " + user.last_name.as(String)
after: full_name = user.first_name! + " " + user.last_name!
Though developers using this method are responsible for the risk of runtime error.