### PR TITLE
Fix crystal logger support

### DIFF
--- a/src/crecto/db_logger.cr
+++ b/src/crecto/db_logger.cr
@@ -29,7 +29,7 @@ module Crecto
 
     def self.set_handler(logger : Logger)
       @@log_handler = logger
-      @@log_handler.level = Logger::INFO
+      @@log_handler.as(Logger).level = Logger::INFO
     end
 
     def self.set_handler(io : IO)


### PR DESCRIPTION
Recently introduced by https://github.com/Crecto/crecto/commit/1e9bae0966626777f34d1e5e9d79c457cba45991 support of Crystal logger is broken giving following error:
```crystal
in lib/crecto/src/crecto/db_logger.cr:32: undefined method 'level=' for IO::ARGF (compile-time type is (IO | Logger | Nil))

      @@log_handler.level = Logger::INFO
```
But changing this line will fix all errors, including integration with [amber framework](https://github.com/amberframework/amber):
```crystal
@@log_handler.as(Logger).level = Logger::INFO
```