### PR TITLE
Changed class checking behaviour

### DIFF
--- a/src/crecto/db_logger.cr
+++ b/src/crecto/db_logger.cr
@@ -8,7 +8,7 @@ module Crecto
 
     def self.log(string, elapsed) : Nil
       if handler = @@log_handler
-        if handler.class == Logger
+        if handler.is_a?(Logger)
           handler.as(Logger).info("#{("%7.7s" % elapsed_text(elapsed)).colorize(:magenta)} #{string.colorize(:blue)}")
         else
           handler.as(IO) << if @@tty


### PR DESCRIPTION
When using Crecto with Amber framework, DB Logger is yielding error:
```crystal
cast from Amber::Environment::Logger to IO+ failed, at /home/grig191/meinkoin_api/lib/crecto/src/crecto/db_logger.cr:14:11:14 (TypeCastError)
  from lib/crecto/src/crecto/db_logger.cr:14:11 in 'log'
  from lib/crecto/src/crecto/db_logger.cr:27:7 in 'log'
  from lib/crecto/src/crecto/adapters/sqlite3_adapter.cr:16:9 in 'exec_execute'
  from lib/crecto/src/crecto/adapters/sqlite3_adapter.cr:49:15 in 'insert'
  from lib/crecto/src/crecto/adapters/base_adapter.cr:50:11 in 'run_on_instance'
  from lib/crecto/src/crecto/repo.cr:211:17 in 'insert'
  from lib/crecto/src/crecto/repo.cr:229:7 in 'insert'
  from tmp/1517613624698_console.cr:4:1 in '__crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:11:3 in '_crystal_main'
  from /usr/share/crystal/src/crystal/main.cr:112:5 in 'main_user_code'
  from /usr/share/crystal/src/crystal/main.cr:101:7 in 'main'
  from /usr/share/crystal/src/crystal/main.cr:135:3 in 'main'
  from __libc_start_main
  from _start
  from ???
```

This error is caused by incorrect class checking in
```crystal
if handler.class == Logger		
```
When custom handler is inherited from Logger it will not pass this check, so we must use this:
```crystal
if handler.is_a?(Logger)
```