### PR TITLE
Allow updating PkeyValues with a hash

### DIFF
--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -266,6 +266,8 @@ module Crecto
                 @{{field[:name].id}} = value.to_i16 if value.to_i16?
               {% elsif field[:type].id.stringify.includes?("Int") %}
                 @{{field[:name].id}} = value.to_i if value.to_i?
+              {% elsif field[:type].id.stringify == "PkeyValue" %}
+                @{{field[:name].id}} = value.to_i if value.to_i?
               {% elsif field[:type].id.stringify.includes?("Float") %}
                 @{{field[:name].id}} = value.to_f if value.to_f?
               {% elsif field[:type].id.stringify == "Bool" %}


### PR DESCRIPTION
This is useful if you want to update an association, as foreign keys
are stored as a PkeyValue, which are just Ints, but need a special case.

I ran into this when adding/updating an association from Crecto-Admin, observing it did nothing. To this point, it might be worth adding a raise in the else block to prevent doing nothing silently.