### PR TITLE
Update pg shard dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ development_dependencies:
 
   pg:
     github: will/crystal-pg
-    version: 0.14.1
+    version: 0.15.0
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3


### PR DESCRIPTION
Hi @fridgerator !

This PR updates `pg` shard to fix breaking-changes on v0.25.0

Crecto itself still requires some changes