### PR TITLE
Allow queries on preloads

### DIFF
--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -1,0 +1,37 @@
+require "./spec_helper"
+
+describe Crecto do
+  describe "Repo::Query" do
+    describe "#combine" do
+      it "should combine 2 queries" do
+        query = Crecto::Repo::Query
+          .select(["user.name"])
+          .where(name: "user_name")
+          .or_where(name: "name_user")
+          .join(:posts)
+          .preload(:posts)
+          .order_by("last_name ASC")
+          .limit(1)
+        
+        query2 = Crecto::Repo::Query
+          .select(["user.name2"])
+          .where(name: "user_name2")
+          .or_where(name: "name_user2")
+          .join(:comments)
+          .preload(:comments)
+          .order_by("first_name ASC")
+          .limit(2)
+        
+        new_query = query.combine(query2)
+
+        new_query.selects.should eq ["user.name", "user.name2"]
+        new_query.wheres.should eq [{:name => "user_name"}, {:name => "user_name2"}]
+        new_query.or_wheres.should eq [{:name => "name_user"}, {:name => "name_user2"}]
+        new_query.joins.should eq [:posts, :comments]
+        new_query.preloads.should eq [{symbol: :posts, query: nil}, {symbol: :comments, query: nil}]
+        new_query.order_bys.should eq ["last_name ASC", "first_name ASC"]
+        new_query.limit.should eq 2
+      end
+    end
+  end
+end

--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -830,6 +830,36 @@ describe Crecto do
         user.user_projects.size.should eq 1
         user.projects.size.should eq 1
       end
+      
+      it "should preload the has_many through association with a query" do
+        user = User.new
+        user.name = "tester"
+        user = Repo.insert(user).instance
+
+        project = Project.new
+        project.name = "project 1"
+        project = Repo.insert(project).instance
+
+        user_project = UserProject.new
+        user_project.project = project
+        user_project.user = user
+        Repo.insert(user_project).instance
+
+        project = Project.new
+        project.name = "project 2"
+        project = Repo.insert(project).instance
+
+        user_project = UserProject.new
+        user_project.project = project
+        user_project.user = user
+        Repo.insert(user_project).instance
+
+        preload_query = Query.where(name: "project 2")
+        users = Repo.all(User, Query.where(id: user.id).preload(:projects, preload_query))
+        user = users[0]
+        user.projects.size.should eq 1
+        user.projects.first.name.should eq "project 2"
+      end
 
       it "should preload the has_many through association with get!" do
         user = quick_create_user("through with get!")

--- a/spec/transactions_spec.cr
+++ b/spec/transactions_spec.cr
@@ -32,10 +32,12 @@ describe Crecto do
         Repo.delete_all(User)
 
         puts "\n\nusers: #{Repo.all(User)}\n\n"
+        sleep 0.1
 
         user = quick_create_user("this should delete")
 
         puts "\n\nusers: #{Repo.all(User)}\n\n"
+        sleep 0.1
 
         multi = Multi.new
         multi.delete(user)


### PR DESCRIPTION
Query#preload methods now accept a `query` parameter.  This will query the preload association table.

fixes #170 

@zbaylin