### PR TITLE
Live transactions

### DIFF
--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -105,6 +105,38 @@ describe Crecto do
       end
     end
 
+    describe "#insert!" do
+      it "should insert the user" do
+        u = User.new
+        u.name = "fridge"
+        u.things = 123
+        u.nope = 12.45432
+        u.yep = false
+        u.stuff = 9993
+        u.pageviews = 10000
+        u.some_date = Time.now.at_beginning_of_hour
+
+        changeset = Repo.insert!(u)
+        changeset.instance.id.should_not eq(nil)
+        changeset.instance.created_at.should_not eq(nil)
+        changeset.instance.updated_at.should_not eq(nil)
+      end
+
+      it "should raise if changeset is invalid (name is nil)" do
+        u = User.new
+        u.things = 123
+        u.nope = 12.45432
+        u.yep = false
+        u.stuff = 9993
+        u.pageviews = 10000
+        u.some_date = Time.now.at_beginning_of_hour
+
+        expect_raises Crecto::InvalidChangeset(User) do
+          Repo.insert!(u)
+        end
+      end
+    end
+
     describe "#all" do
       it "should return rows" do
         query = Query
@@ -622,6 +654,52 @@ describe Crecto do
       end
     end
 
+    describe "#update!" do
+      it "should update the model" do
+        now = Time.now.at_beginning_of_hour
+        u = User.new
+        u.name = "fridge"
+        u.things = 123
+        u.nope = 12.45432
+        u.yep = false
+        u.stuff = 9993
+        u.pageviews = 123245667788
+        u.some_date = now
+        changeset = Repo.insert(u)
+        u = changeset.instance
+        u.some_date.as(Time).to_local.should eq(now)
+        created_at = u.created_at
+        u.name = "new name"
+        changeset = Repo.update!(u)
+        u = changeset.instance
+        u.some_date.as(Time).to_local.should eq(now)
+        u.created_at.should eq(created_at)
+        changeset.instance.name.should eq("new name")
+        changeset.valid?.should eq(true)
+        changeset.instance.updated_at.as(Time).to_local.epoch_ms.should be_close(Time.now.epoch_ms, 2000)
+      end
+
+      it "should raise if changeset is invalid (name is nil)" do
+        now = Time.now.at_beginning_of_hour
+        u = User.new
+        u.name = "fridge"
+        u.things = 123
+        u.nope = 12.45432
+        u.yep = false
+        u.stuff = 9993
+        u.pageviews = 123245667788
+        u.some_date = now
+        changeset = Repo.insert(u)
+        u = changeset.instance
+        u.some_date.as(Time).to_local.should eq(now)
+        created_at = u.created_at
+        u.name = nil
+        expect_raises Crecto::InvalidChangeset(User) do
+          Repo.update!(u)
+        end
+      end
+    end
+
     describe "#delete" do
       it "should delete the model" do
         u = User.new
@@ -691,6 +769,38 @@ describe Crecto do
         Repo.all(UserProject, Query.where(user_id: user.id)).size.should eq 0
       end
     end
+
+    describe "#delete!" do
+      it "should delete the model" do
+        u = User.new
+        u.name = "fridge"
+        u.things = 123
+        u.nope = 12.45432
+        u.yep = false
+        u.stuff = 9993
+        u.pageviews = 1234512341234
+        changeset = Repo.insert(u)
+        u = changeset.instance
+        changeset = Repo.delete!(u)
+        changeset.valid?.should be_true
+      end
+
+      it "should raise an error if the changeset is invalid (dangling dependents)" do
+        u = User.new
+        u.name = "fridge"
+        u = Repo.insert(u).instance
+        p = Post.new
+        p.user = u
+        p = Repo.insert(p).instance
+
+        # This actually raises a PQ error (also on #delete)
+        # TODO: Wrap this in a changeset error
+        expect_raises(PQ::PQError) do
+          Repo.delete!(u)
+        end
+      end
+    end
+
 
     describe "#update_all" do
       it "should update multiple records" do

--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -786,6 +786,7 @@ describe Crecto do
       end
 
       it "should raise an error if the changeset is invalid (dangling dependents)" do
+        next unless Repo.config.adapter == Crecto::Adapters::Postgres
         u = User.new
         u.name = "fridge"
         u = Repo.insert(u).instance

--- a/src/crecto/errors/invalid_changeset.cr
+++ b/src/crecto/errors/invalid_changeset.cr
@@ -1,0 +1,20 @@
+require "./crecto_error"
+
+module Crecto
+  # :nodoc:
+  class InvalidChangeset(T) < CrectoError
+    getter changeset
+
+    def initialize(@changeset : Changeset::Changeset(T))
+    end
+
+    def message
+      error_list = [] of String
+      changeset.errors.each do |error|
+        error_list += error.map { |field, message| "#{field}: #{message}" }
+      end
+
+      "Failed to #{changeset.action} #{changeset.instance.class}: #{error_list.join(", ")}"
+    end
+  end
+end

--- a/src/crecto/live_transaction.cr
+++ b/src/crecto/live_transaction.cr
@@ -1,0 +1,30 @@
+require "./multi"
+
+module Crecto
+  class LiveTransaction(T)
+    def initialize(@tx : DB::Transaction, @repo : T)
+    end
+
+    {% for type in %w[insert insert! delete delete! update update!] %}
+      def {{type.id}}(queryable : Crecto::Model)
+        @repo.{{type.id}}(queryable, @tx)
+      end
+
+      def {{type.id}}(changeset : Crecto::Changeset::Changeset)
+        {{type.id}}(changeset.instance)
+      end
+    {% end %}
+
+    def delete_all(queryable, query = Crecto::Repo::Query.new)
+      @repo.delete_all(queryable, query, @tx)
+    end
+
+    def update_all(queryable, query, update_hash : Multi::UpdateHash)
+      @repo.update_all(queryable, query, update_hash, @tx)
+    end
+
+    def update_all(queryable, query, update_tuple : NamedTuple)
+      update_all(queryable, query, update_tuple.to_h)
+    end
+  end
+end

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -491,6 +491,18 @@ module Crecto
       multi
     end
 
+    # Run a live transaction. As opposed to transactions using `Multi` every
+    # operation on the yielded `LiveTransaction` object is executed immediately.
+    # This allows checking for results of previous operations. Any raise inside
+    # the block will roll back the transaction.
+    #
+    # ```
+    # Crecto::Repo.transaction! do |tx|
+    #   tx.insert!(user)
+    #   post = Post.new.tap { |p| p.user = user }
+    #   tx.insert!(post)
+    # end
+    # ```
     def transaction!
       config.get_connection.transaction do |tx|
         begin

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -491,6 +491,17 @@ module Crecto
       multi
     end
 
+    def transaction!
+      config.get_connection.transaction do |tx|
+        begin
+          yield LiveTransaction.new(tx, self)
+        rescue error : Exception
+          tx.rollback
+          raise error
+        end
+      end
+    end
+
     {% for operation in %w[insert update delete] %}
       private def run_operation(operation : Multi::{{operation.camelcase.id}}, tx)
         {{operation.id}}(operation.instance, tx)

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -259,6 +259,31 @@ module Crecto
       insert(changeset.instance)
     end
 
+    # Insert a schema instance into the data store or raise if the resulting
+    # changeset is invalid.
+    #
+    # ```
+    # user = User.new
+    # Repo.insert!(user)
+    # ```
+    def insert!(queryable_instance, tx : DB::Transaction? = nil)
+      insert(queryable_instance, tx).tap do |changeset|
+        raise InvalidChangeset.new(changeset) unless changeset.valid?
+      end
+    end
+
+    # Insert a changeset instance into the data store or raise if the
+    # resulting changest is invalid.
+    #
+    # ```
+    # user = User.new
+    # changeset = User.changeset(user)
+    # Repo.insert!(changeset)
+    # ```
+    def insert!(changeset : Crecto::Changeset::Changeset)
+      insert!(changeset.instance)
+    end
+
     # Update a shema instance in the data store.
     #
     # ```
@@ -298,6 +323,28 @@ module Crecto
     # ```
     def update(changeset : Crecto::Changeset::Changeset)
       update(changeset.instance)
+    end
+
+    # Update a schema instance in the data store or raise if the resulting
+    # changeset is invalid
+    #
+    # ```
+    # Repo.update!(user)
+    # ```
+    def update!(queryable_instance, tx : DB::Transaction? = nil)
+      update(queryable_instance, tx).tap do |changeset|
+        raise InvalidChangeset.new(changeset) unless changeset.valid?
+      end
+    end
+
+    # Update a changeset instance in the data store or raise if the resulting
+    # changeset is invalid
+    #
+    # ```
+    # Repo.update(changeset)
+    # ```
+    def update!(changeset : Crecto::Changeset::Changeset)
+      update!(changeset.instance)
     end
 
     # Update multipile records with a single query
@@ -355,6 +402,29 @@ module Crecto
     # ```
     def delete(changeset : Crecto::Changeset::Changeset)
       delete(changeset.instance)
+    end
+
+
+    # Delete a schema instance from the data store or raise if the resulting
+    # changeset is invalid
+    #
+    # ```
+    # Repo.delete!(user)
+    # ```
+    def delete!(queryable_instance, tx : DB::Transaction? = nil)
+      delete(queryable_instance, tx).tap do |changeset|
+        raise InvalidChangeset.new(changeset) unless changeset.valid?
+      end
+    end
+
+    # Delete a changeset instance from the data store or raise if the
+    # resulting changeset is invalid
+    #
+    # ```
+    # Repo.delete!(changeset)
+    # ```
+    def delete!(changeset : Crecto::Changeset::Changeset)
+      delete!(changeset.instance)
     end
 
     # Delete multipile records with a single query


### PR DESCRIPTION
This would allow running transactions like this:

``` crystal
begin
  Repo.transaction! do |tx|
    user = User.new
    user.name = "Jokke"
    user = tx.insert!(user).instance
    post = Repo.get(post_id)
    like = Like.new
    like.user = user
    like.post = post
    tx.insert!(like)
  end
rescue error : Exception
  respond_with(error: error)
end
```

If anything inside the block raises an error (eg. exclamation mark versions of `create`, `update` or `delete`) the transaction will be rolled back and the error will be re-raised.
