### PR TITLE
Multi run block

### DIFF
--- a/src/crecto/changeset/generic.cr
+++ b/src/crecto/changeset/generic.cr
@@ -1,0 +1,35 @@
+module Crecto
+  module Changeset(T)
+    class GenericChangeset
+      # :nodoc:
+      property instance : Crecto::Model
+      # :nodoc:
+      property action : Symbol?
+      # :nodoc:
+      property errors = [] of Hash(Symbol, String)
+      # :nodoc:
+      property changes = [] of Hash(Symbol, DbValue | ArrayDbValue)
+      # :nodoc:
+      property source : Hash(Symbol, DbValue)? | Hash(Symbol, ArrayDbValue)?
+      
+      private property valid = true
+
+      def self.from_changeset(changeset)
+        new(
+          changeset.instance,
+          changeset.action,
+          changeset.errors,
+          changeset.changes,
+          changeset.valid?
+        )
+      end
+
+      def initialize(@instance, @action, @errors, @changes, @valid)
+      end
+
+      def valid?
+        @valid
+      end
+    end
+  end
+end

--- a/src/crecto/multi.cr
+++ b/src/crecto/multi.cr
@@ -36,7 +36,7 @@ module Crecto
     # :nodoc:
     record UpdateAll, queryable : Crecto::Model.class, query : Crecto::Repo::Query, update_hash : UpdateHash
     # :nodoc:
-    property operations = Array(Insert | Delete | DeleteAll | Update | UpdateAll).new
+    property operations = Array(Insert | Delete | DeleteAll | Update | UpdateAll | Proc(MultiRunType, Nil)).new
 
     {% for type in %w[insert delete update] %}
       def {{type.id}}(queryable_instance : Crecto::Model)
@@ -47,6 +47,10 @@ module Crecto
         {{type.id}}(changeset.instance)
       end
     {% end %}
+
+    def run(&block: MultiRunType -> Nil)
+      operations.push block
+    end
 
     def delete_all(queryable, query = Crecto::Repo::Query.new)
       operations.push(DeleteAll.new(queryable, query))

--- a/src/types.cr
+++ b/src/types.cr
@@ -10,3 +10,5 @@ alias PkeyValue = String | Int32 | Int64 | Nil
 alias WhereType = Hash(Symbol, PkeyValue) | Hash(Symbol, DbValue) | Hash(Symbol, Array(DbValue)) | Hash(Symbol, Array(PkeyValue)) | Hash(Symbol, Array(Int32)) | Hash(Symbol, Array(Int64)) | Hash(Symbol, Array(String)) | Hash(Symbol, Int32 | String) | Hash(Symbol, Int64 | String) | Hash(Symbol, Int32) | Hash(Symbol, Int64) | Hash(Symbol, Nil) | Hash(Symbol, String) | Hash(Symbol, Int32 | Int64 | String) | Hash(Symbol, Int32 | Int64 | String | Nil) | NamedTuple(clause: String, params: Array(DbValue | PkeyValue))
 # :nodoc:
 alias Json = JSON::Any
+# :nodoc:
+alias MultiRunType = Bool | Crecto::Changeset::GenericChangeset | DB::ExecResult | DB::ResultSet | Nil


### PR DESCRIPTION
This needs more specs, not for merging yet, just feedback.

closes #160 

Allows running arbitrary code in `run` blocks in multi transactions.

```ruby
multi = Multi.new

multi.insert(user)
multi.run do |prev|
  # prev is: Bool | Crecto::Changeset::GenericChangeset | DB::ExecResult | DB::ResultSet | Nil
  if prev.is_a?(Crecto::Changeset::GenericChangeset)
    prev.instance
    prev.action
    prev.errors
    prev.changes
    prev.source
    prev.valid?
  end
end

Repo.transaction(multi)
```

Since `Proc` cant be a generic type (`Crecto::Model`) I had to create a "generic" changeset.

@jreinert Has another proposal which I also like and is very simple #175 

I guess I wanted to get some feedback from users.

I like the `multi` approach since it acts as a sort of "multi builder" just like a query builder.  But I'm curious if people are even using this feature.

@jwoertink @jianghengle @faultyserver 