### PR TITLE
Add parentheses around grouped where clauses

### DIFF
--- a/spec/adapters/mysql_adapter_spec.cr
+++ b/spec/adapters/mysql_adapter_spec.cr
@@ -43,7 +43,7 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
       check_sql do |sql|
         sql.should eq([
           "INSERT INTO users (name, things, smallnum, nope, yep, some_date, pageviews, unique_field, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          "SELECT * FROM users WHERE id = LAST_INSERT_ID()",
+          "SELECT * FROM users WHERE (id = LAST_INSERT_ID())",
         ])
       end
     end
@@ -53,7 +53,7 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
       Crecto::Adapters.clear_sql
       Repo.get(User, user.instance.id)
       check_sql do |sql|
-        sql.should eq(["SELECT * FROM users WHERE id=? LIMIT 1"])
+        sql.should eq(["SELECT * FROM users WHERE (id=?) LIMIT 1"])
       end
     end
 
@@ -66,7 +66,7 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
         .limit(1)
       Repo.all(User, query)
       check_sql do |sql|
-        sql.should eq(["SELECT users.* FROM users WHERE  users.name=? AND users.things < ? ORDER BY users.name ASC, users.things DESC LIMIT 1"])
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.name=?) AND (users.things < ?) ORDER BY users.name ASC, users.things DESC LIMIT 1"])
       end
     end
 
@@ -78,8 +78,8 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
       Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq([
-          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, unique_field=?, created_at=?, updated_at=?, id=? WHERE id=?",
-          "SELECT * FROM users WHERE id=?",
+          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, unique_field=?, created_at=?, updated_at=?, id=? WHERE (id=?)",
+          "SELECT * FROM users WHERE (id=?)",
         ])
       end
     end
@@ -90,10 +90,10 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
       Repo.delete(changeset.instance)
       check_sql do |sql|
         sql.should eq(
-          ["DELETE FROM addresses WHERE  addresses.user_id=?",
-           "SELECT user_projects.project_id FROM user_projects WHERE  user_projects.user_id=?",
-           "SELECT * FROM users WHERE id=?",
-           "DELETE FROM users WHERE id=?"])
+          ["DELETE FROM addresses WHERE  (addresses.user_id=?)",
+           "SELECT user_projects.project_id FROM user_projects WHERE  (user_projects.user_id=?)",
+           "SELECT * FROM users WHERE (id=?)",
+           "DELETE FROM users WHERE (id=?)"])
       end
     end
 
@@ -103,7 +103,7 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
       query = Query.where(things: nil)
       Repo.all(User, query)
       check_sql do |sql|
-        sql.should eq(["SELECT users.* FROM users WHERE  users.things IS NULL"])
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
   end

--- a/spec/adapters/postgres_adapter_spec.cr
+++ b/spec/adapters/postgres_adapter_spec.cr
@@ -46,7 +46,7 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
       Crecto::Adapters.clear_sql
       Repo.get(User, user.instance.id)
       check_sql do |sql|
-        sql.should eq(["SELECT * FROM users WHERE id=$1 LIMIT 1"])
+        sql.should eq(["SELECT * FROM users WHERE (id=$1) LIMIT 1"])
       end
     end
 
@@ -59,7 +59,7 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
         .limit(1)
       Repo.all(User, query)
       check_sql do |sql|
-        sql.should eq(["SELECT users.* FROM users WHERE  users.name=$1 AND users.things < $2 ORDER BY users.name ASC, users.things DESC LIMIT 1"])
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.name=$1) AND (users.things < $2) ORDER BY users.name ASC, users.things DESC LIMIT 1"])
       end
     end
 
@@ -70,7 +70,7 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
       Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq(["UPDATE users SET (name, things, smallnum, nope, yep, some_date, pageviews, unique_field, created_at, updated_at, id) = \
-          ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) WHERE id=$12 RETURNING *"])
+          ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) WHERE (id=$12) RETURNING *"])
       end
     end
 
@@ -80,9 +80,9 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
       Repo.delete(changeset.instance)
       check_sql do |sql|
         sql.should eq(
-          ["DELETE FROM addresses WHERE  addresses.user_id=$1",
-           "SELECT user_projects.project_id FROM user_projects WHERE  user_projects.user_id=$1",
-           "DELETE FROM users WHERE id=$1 RETURNING *"])
+          ["DELETE FROM addresses WHERE  (addresses.user_id=$1)",
+           "SELECT user_projects.project_id FROM user_projects WHERE  (user_projects.user_id=$1)",
+           "DELETE FROM users WHERE (id=$1) RETURNING *"])
       end
     end
 
@@ -92,7 +92,7 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
       query = Query.where(things: nil)
       Repo.all(User, query)
       check_sql do |sql|
-        sql.should eq(["SELECT users.* FROM users WHERE  users.things IS NULL"])
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
   end

--- a/spec/adapters/sqlite3_adapter_spec.cr
+++ b/spec/adapters/sqlite3_adapter_spec.cr
@@ -43,7 +43,7 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
       check_sql do |sql|
         sql.should eq([
           "INSERT INTO users (name, things, smallnum, nope, yep, some_date, pageviews, unique_field, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-          "SELECT * FROM users WHERE id = '#{u.instance.id}'",
+          "SELECT * FROM users WHERE (id = '#{u.instance.id}')",
         ])
       end
     end
@@ -53,7 +53,7 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
       Crecto::Adapters.clear_sql
       Repo.get(User, user.instance.id)
       check_sql do |sql|
-        sql.should eq(["SELECT * FROM users WHERE id=? LIMIT 1"])
+        sql.should eq(["SELECT * FROM users WHERE (id=?) LIMIT 1"])
       end
     end
 
@@ -66,7 +66,7 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
         .limit(1)
       Repo.all(User, query)
       check_sql do |sql|
-        sql.should eq(["SELECT users.* FROM users WHERE  users.name=? AND users.things < ? ORDER BY users.name ASC, users.things DESC LIMIT 1"])
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.name=?) AND (users.things < ?) ORDER BY users.name ASC, users.things DESC LIMIT 1"])
       end
     end
 
@@ -78,8 +78,8 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
       Repo.update(changeset.instance)
       check_sql do |sql|
         sql.should eq([
-          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, unique_field=?, created_at=?, updated_at=?, id=? WHERE id=?",
-          "SELECT * FROM users WHERE id=?",
+          "UPDATE users SET name=?, things=?, smallnum=?, nope=?, yep=?, some_date=?, pageviews=?, unique_field=?, created_at=?, updated_at=?, id=? WHERE (id=?)",
+          "SELECT * FROM users WHERE (id=?)",
         ])
       end
     end
@@ -90,10 +90,10 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
       Repo.delete(changeset.instance)
       check_sql do |sql|
         sql.should eq(
-          ["DELETE FROM addresses WHERE  addresses.user_id=?",
-           "SELECT user_projects.project_id FROM user_projects WHERE  user_projects.user_id=?",
-           "SELECT * FROM users WHERE id=?",
-           "DELETE FROM users WHERE id=?"])
+          ["DELETE FROM addresses WHERE  (addresses.user_id=?)",
+           "SELECT user_projects.project_id FROM user_projects WHERE  (user_projects.user_id=?)",
+           "SELECT * FROM users WHERE (id=?)",
+           "DELETE FROM users WHERE (id=?)"])
       end
     end
 
@@ -103,7 +103,7 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
       query = Query.where(things: nil)
       Repo.all(User, query)
       check_sql do |sql|
-        sql.should eq(["SELECT users.* FROM users WHERE  users.things IS NULL"])
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
   end

--- a/src/crecto/adapters/mysql_adapter.cr
+++ b/src/crecto/adapters/mysql_adapter.cr
@@ -31,7 +31,7 @@ module Crecto
       private def self.get(conn, queryable, id)
         q = ["SELECT *"]
         q.push "FROM #{queryable.table_name}"
-        q.push "WHERE #{queryable.primary_key_field}=?"
+        q.push "WHERE (#{queryable.primary_key_field}=?)"
         q.push "LIMIT 1"
 
         execute(conn, q.join(" "), [id])
@@ -51,7 +51,7 @@ module Crecto
 
         if changeset.instance.class.use_primary_key?
           last_insert_id = changeset.instance.pkey_value.nil? ? "LAST_INSERT_ID()" : "'#{changeset.instance.pkey_value.not_nil!}'"
-          execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field} = #{last_insert_id}")
+          execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE (#{changeset.instance.class.primary_key_field} = #{last_insert_id})")
         else
           query
         end
@@ -70,21 +70,21 @@ module Crecto
 
         q = update_begin(changeset.instance.class.table_name, fields_values)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=?"
+        q.push "(#{changeset.instance.class.primary_key_field}=?)"
 
         exec_execute(conn, q.join(" "), fields_values[:values] + [changeset.instance.pkey_value])
-        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}=?", [changeset.instance.pkey_value])
+        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE (#{changeset.instance.class.primary_key_field}=?)", [changeset.instance.pkey_value])
       end
 
       private def self.delete(conn, changeset)
         q = delete_begin(changeset.instance.class.table_name)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=?"
+        q.push "(#{changeset.instance.class.primary_key_field}=?)"
 
         if conn.is_a?(DB::TopLevelTransaction)
           exec_execute(conn, q.join(" "), [changeset.instance.pkey_value])
         else
-          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}=?", [changeset.instance.pkey_value])
+          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE (#{changeset.instance.class.primary_key_field}=?)", [changeset.instance.pkey_value])
           exec_execute(conn, q.join(" "), [changeset.instance.pkey_value])
           sel
         end

--- a/src/crecto/adapters/postgres_adapter.cr
+++ b/src/crecto/adapters/postgres_adapter.cr
@@ -20,7 +20,7 @@ module Crecto
 
         q = update_begin(changeset.instance.class.table_name, fields_values)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=?"
+        q.push "(#{changeset.instance.class.primary_key_field}=?)"
         q.push "RETURNING *"
 
         execute(conn, position_args(q.join(" ")), fields_values[:values] + [changeset.instance.pkey_value])

--- a/src/crecto/adapters/sqlite3_adapter.cr
+++ b/src/crecto/adapters/sqlite3_adapter.cr
@@ -31,7 +31,7 @@ module Crecto
       private def self.get(conn, queryable, id)
         q = ["SELECT *"]
         q.push "FROM #{queryable.table_name}"
-        q.push "WHERE #{queryable.primary_key_field}=?"
+        q.push "WHERE (#{queryable.primary_key_field}=?)"
         q.push "LIMIT 1"
 
         execute(conn, q.join(" "), [id])
@@ -49,7 +49,7 @@ module Crecto
         res = exec_execute(conn, q.join(" "), fields_values[:values])
         if changeset.instance.class.use_primary_key?
           last_insert_id = changeset.instance.pkey_value.nil? ? res.last_insert_id : changeset.instance.pkey_value.not_nil!
-          execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field} = '#{last_insert_id}'")
+          execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE (#{changeset.instance.class.primary_key_field} = '#{last_insert_id}')")
         else
           res
         end
@@ -68,21 +68,21 @@ module Crecto
 
         q = update_begin(changeset.instance.class.table_name, fields_values)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=?"
+        q.push "(#{changeset.instance.class.primary_key_field}=?)"
 
         exec_execute(conn, q.join(" "), fields_values[:values] + [changeset.instance.pkey_value])
-        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}=?", [changeset.instance.pkey_value])
+        execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE (#{changeset.instance.class.primary_key_field}=?)", [changeset.instance.pkey_value])
       end
 
       private def self.delete(conn, changeset)
         q = delete_begin(changeset.instance.class.table_name)
         q.push "WHERE"
-        q.push "#{changeset.instance.class.primary_key_field}=?"
+        q.push "(#{changeset.instance.class.primary_key_field}=?)"
 
         if conn.is_a?(DB::TopLevelTransaction)
           exec_execute(conn, q.join(" "), [changeset.instance.pkey_value])
         else
-          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE #{changeset.instance.class.primary_key_field}=?", [changeset.instance.pkey_value])
+          sel = execute(conn, "SELECT * FROM #{changeset.instance.class.table_name} WHERE (#{changeset.instance.class.primary_key_field}=?)", [changeset.instance.pkey_value])
           exec_execute(conn, q.join(" "), [changeset.instance.pkey_value])
           sel
         end


### PR DESCRIPTION
A Query like this `Query.where("name=? OR name=?", ["fred", "bil"]).where(things: 123)` previously generated sql that looked like this:

`SELECT users.* FROM users WHERE name=? OR name=? AND  users.things=?`

This PR adds parentheses around where statements:

`SELECT users.* FROM users WHERE (name=? OR name=?) AND  (users.things=?)`