### PR TITLE
Fix required fields checker to compare with nil

### DIFF
--- a/src/crecto/changeset/changeset.cr
+++ b/src/crecto/changeset/changeset.cr
@@ -104,7 +104,7 @@ module Crecto
       private def check_required!
         return unless REQUIRED_FIELDS.has_key?(@class_key)
         REQUIRED_FIELDS[@class_key].each do |field|
-          add_error(field.to_s, "is required") unless @instance_hash[field]?
+          add_error(field.to_s, "is required") if @instance_hash[field].nil?
         end
       end
 


### PR DESCRIPTION
The PR for fixing the required fields checker.

It has added an unnecessary error when the field type is `Bool` and the value is `false`.  
I assume the original purpose of this method is checking that "the field has `value`" so that comparing with `nil` should be appropriate.

e.g.  
```crystal
class Sample < Crecto::Model
  schema "samples" do
    field :id, String, primary_key: true
    field :is_deleted, Bool, default: false
  end
end

validate_required [:id, :is_deleted]
# => cannot insert when is_deleted == false
```