### PR TITLE
Implement lock feature

### DIFF
--- a/spec/adapters/mysql_adapter_spec.cr
+++ b/spec/adapters/mysql_adapter_spec.cr
@@ -106,5 +106,20 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
         sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
+
+    it "should generate sql for query syntax with lock" do
+      query = Query
+        .where(name: "fridge")
+        .where("users.things < ?", [124])
+        .order_by("users.name ASC")
+        .order_by("users.things DESC")
+        .limit(1)
+      Repo.config.get_connection.transaction do |tx|
+        Repo.lock(tx, User, query)
+      end
+      check_sql do |sql|
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.name=?) AND (users.things < ?) ORDER BY users.name ASC, users.things DESC LIMIT 1 FOR UPDATE"])
+      end
+    end
   end
 end

--- a/spec/adapters/postgres_adapter_spec.cr
+++ b/spec/adapters/postgres_adapter_spec.cr
@@ -95,5 +95,20 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
         sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
+
+    it "should generate sql for query syntax with lock" do
+      query = Query
+        .where(name: "fridge")
+        .where("users.things < ?", [124])
+        .order_by("users.name ASC")
+        .order_by("users.things DESC")
+        .limit(1)
+      Repo.config.get_connection.transaction do |tx|
+        Repo.lock(tx, User, query)
+      end
+      check_sql do |sql|
+        sql.should eq(["SELECT users.* FROM users WHERE  (users.name=$1) AND (users.things < $2) ORDER BY users.name ASC, users.things DESC LIMIT 1 FOR UPDATE"])
+      end
+    end
   end
 end

--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -1190,6 +1190,34 @@ describe Crecto do
       end
     end
 
+    describe "#lock" do
+      it "should return rows" do
+        if Repo.config.adapter != Crecto::Adapters::SQLite3
+          users = [] of User
+          Repo.config.get_connection.transaction do |tx|
+            users = Repo.lock(tx, User)
+          end
+          users.size.should be > 0
+        end
+      end
+
+      it "should return rows with Query" do
+        if Repo.config.adapter != Crecto::Adapters::SQLite3
+          query = Query
+            .where(name: "fridge")
+            .where("users.things < ?", [124])
+            .order_by("users.name ASC")
+            .order_by("users.things DESC")
+            .limit(1)
+          users = [] of User
+          Repo.config.get_connection.transaction do |tx|
+            users = Repo.lock(tx, User, query)
+          end
+          users.size.should be > 0
+        end
+      end
+    end
+
     # keep this at the end
     describe "#delete_all" do
       it "should delete destroy dependents" do

--- a/src/crecto/adapters/base_adapter.cr
+++ b/src/crecto/adapters/base_adapter.cr
@@ -13,6 +13,8 @@ module Crecto
           all(conn, queryable, query)
         when :delete_all
           delete(conn, queryable, query)
+        when :lock
+          all(conn, queryable, query, true)
         end
       end
 
@@ -134,7 +136,7 @@ module Crecto
         "SELECT #{ag}(#{queryable.table_name}.#{field}) from #{queryable.table_name}"
       end
 
-      private def all(conn, queryable, query)
+      private def all(conn, queryable, query, for_update = false)
         params = [] of DbValue | Array(DbValue)
 
         q = ["SELECT"]
@@ -152,6 +154,8 @@ module Crecto
         q.push limit(query) unless query.limit.nil?
         q.push offset(query) unless query.offset.nil?
         q.push "GROUP BY #{query.group_bys}" if !query.group_bys.nil?
+
+        q.push "FOR UPDATE" if for_update
 
         execute(conn, position_args(q.join(" ")), params)
       end

--- a/src/crecto/live_transaction.cr
+++ b/src/crecto/live_transaction.cr
@@ -26,5 +26,9 @@ module Crecto
     def update_all(queryable, query, update_tuple : NamedTuple)
       update_all(queryable, query, update_tuple.to_h)
     end
+
+    def lock(queryable, query = Crecto::Repo::Query.new)
+      @repo.lock(@tx, queryable, query)
+    end
   end
 end

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -514,6 +514,20 @@ module Crecto
       end
     end
 
+    # Returns a list of locked *queryable* instances.  Accepts an optional `query`
+    #
+    # ```
+    # Crecto::Repo.config.get_connection.transaction do |tx|
+    #   users = Crecto::Repo.lock(tx, User)
+    # end
+    # ```
+    def lock(tx : DB::Transaction, queryable, query = Query.new) : Array
+      raise Crecto::InvalidAdapter.new "SQLite3 cannot use lock feature." if config.adapter == Crecto::Adapters::SQLite3
+      q = config.adapter.run(tx, :lock, queryable, query).as(DB::ResultSet)
+      results = queryable.from_rs(q)
+      results
+    end
+
     {% for operation in %w[insert update delete] %}
       private def run_operation(operation : Multi::{{operation.camelcase.id}}, tx)
         {{operation.id}}(operation.instance, tx)


### PR DESCRIPTION
The PR for implementing the `lock` feature.

This change enables LiveTransaction to request `SELECT ~ FOR UPDATE` on MySQL and Postgres.

Now it returns the list of `queryable` by `Crecto::Repo::Query`, but/so that the class which does not have the primary key can also use this `lock` feature.

e.g.  
```crystal
# CREATE TABLE `samples` (`id` VARCHAR(36), `number` INT UNSIGNED, `updated_at` TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3), `created_at` TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3), PRIMARY KEY USING BTREE (`id`));

class Sample < Crecto::Model
  schema "samples" do
    field :id, String, primary_key: true
    field :number, Int32
  end
end

sample = Sample.new
sample.id = "7eb498c2-e63c-4be9-814f-b67d32a7ce38"
sample.number = 0
Repo.insert sample

Repo.transaction! do |tx|
  puts "start transaction"
  arr = tx.lock(Sample, Crecto::Repo::Query.where(id: "7eb498c2-e63c-4be9-814f-b67d32a7ce38"))
  sample = arr[0]
  sample.number = sample.number.as(Int32) + 1
  tx.update sample

  # test rollback and lock release with timeout, Exception...
  # sleep(2)
  # raise Exception.new
end
```