### PR TITLE
Allow JOIN clause string

### DIFF
--- a/spec/adapters/mysql_adapter_spec.cr
+++ b/spec/adapters/mysql_adapter_spec.cr
@@ -106,5 +106,13 @@ if Repo.config.adapter == Crecto::Adapters::Mysql
         sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
+
+    it "should generates JOIN clause from string" do
+      query = Query.join "INNER JOIN users ON users.id = posts.user_id"
+      Repo.all(Post, query)
+      check_sql do |sql|
+        sql.should eq(["SELECT posts.* FROM posts INNER JOIN users ON users.id = posts.user_id"])
+      end
+    end
   end
 end

--- a/spec/adapters/postgres_adapter_spec.cr
+++ b/spec/adapters/postgres_adapter_spec.cr
@@ -95,5 +95,13 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
         sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
+
+    it "should generates JOIN clause from string" do
+      query = Query.join "INNER JOIN users ON users.id = posts.user_id"
+      Repo.all(Post, query)
+      check_sql do |sql|
+        sql.should eq(["SELECT posts.* FROM posts INNER JOIN users ON users.id = posts.user_id"])
+      end
+    end
   end
 end

--- a/spec/adapters/sqlite3_adapter_spec.cr
+++ b/spec/adapters/sqlite3_adapter_spec.cr
@@ -106,5 +106,13 @@ if Repo.config.adapter == Crecto::Adapters::SQLite3
         sql.should eq(["SELECT users.* FROM users WHERE  (users.things IS NULL)"])
       end
     end
+
+    it "should generates JOIN clause from string" do
+      query = Query.join "INNER JOIN users ON users.id = posts.user_id"
+      Repo.all(Post, query)
+      check_sql do |sql|
+        sql.should eq(["SELECT posts.* FROM posts INNER JOIN users ON users.id = posts.user_id"])
+      end
+    end
   end
 end

--- a/spec/query_spec.cr
+++ b/spec/query_spec.cr
@@ -33,5 +33,24 @@ describe Crecto do
         new_query.limit.should eq 2
       end
     end
+
+    describe "#join" do
+      it "should add JOIN clause string from Query class" do
+        query = Crecto::Repo::Query.join("INNER JOIN users ON users.id = posts.user_id")
+
+        query.joins.size.should eq 1
+        query.joins[0].should eq "INNER JOIN users ON users.id = posts.user_id"
+      end
+
+      it "should add JOIN clause string from Query instance" do
+        query = Crecto::Repo::Query.new
+        query.joins.size.should eq 0
+
+        query = query.join("INNER JOIN users ON users.id = posts.user_id")
+
+        query.joins.size.should eq 1
+        query.joins[0].should eq "INNER JOIN users ON users.id = posts.user_id"
+      end
+    end
   end
 end

--- a/src/crecto/adapters/base_adapter.cr
+++ b/src/crecto/adapters/base_adapter.cr
@@ -252,10 +252,14 @@ module Crecto
 
       private def joins(queryable, query, params)
         joins = query.joins.map do |join|
-          if queryable.through_key_for_association(join)
-            join_through(queryable, join)
+          if join.is_a? Symbol
+            if queryable.through_key_for_association(join)
+              join_through(queryable, join)
+            else
+              join_single(queryable, join)
+            end
           else
-            join_single(queryable, join)
+            join
           end
         end
         joins.join(" ")

--- a/src/crecto/repo/query.cr
+++ b/src/crecto/repo/query.cr
@@ -9,7 +9,7 @@ module Crecto
       property selects : Array(String)
       property wheres = [] of WhereType
       property or_wheres = [] of WhereType
-      property joins = [] of Symbol
+      property joins = [] of Symbol | String
       property preloads = [] of NamedTuple(symbol: Symbol, query: Query?)
       property order_bys = [] of String
       property limit : Int32?
@@ -113,6 +113,15 @@ module Crecto
       # ```
       def self.join(join_association : Symbol)
         self.new.join(join_association)
+      end
+
+      # Join query with a String
+      #
+      # ```
+      # Query.join("INNER JOIN users ON users.id = posts.user_id")
+      # ```
+      def self.join(join_string : String)
+        self.new.join(join_string)
       end
 
       # Preload associations
@@ -322,6 +331,17 @@ module Crecto
       # ```
       def join(join_association : Symbol)
         @joins.push(join_association)
+        self
+      end
+
+      # Join query with a String
+      #
+      # ```
+      # q = Query.new
+      # q.join("INNER JOIN users ON users.id = posts.user_id")
+      # ```
+      def join(join_string : String)
+        @joins.push(join_string)
         self
       end
 


### PR DESCRIPTION
The PR for adding the option to write JOIN clause string directly.

It will be useful to query the particular table with the condition related to another table's columns,  
 which is difficult to achieve by association features.

I referred to the implementation of `WHERE` clause.  
I don't think the option to pass `params` to fill `?` in the string is so useful here, because in my understanding JOIN query requires to write `table_name.column_name` without single quotations.