### PR TITLE
skip randomly failing delete_all spec for sqlite

### DIFF
--- a/spec/transactions_spec.cr
+++ b/spec/transactions_spec.cr
@@ -45,6 +45,9 @@ describe Crecto do
       end
 
       it "with a valid delete_all, should delete all records" do
+        # Skip this spec for sqlite since it randomly fails on travis
+        next if Repo.config.adapter == Crecto::Adapters::SQLite3
+
         2.times do
           quick_create_user("test")
         end


### PR DESCRIPTION
see #192 

the delete_all spec will also randomly fail. 