### PR TITLE
only query preloaded belongs_to relations with ids that aren't nil

### DIFF
--- a/spec/repo_spec.cr
+++ b/spec/repo_spec.cr
@@ -1125,6 +1125,14 @@ describe Crecto do
         posts[0].user.id.should eq(user.id)
       end
 
+      it "should set the association to nil if foreign key is missing for belongs_to" do
+        post = Post.new
+        post = Repo.insert(post).instance
+
+        posts = Repo.all(Post, Query.where(id: post.id).preload(:user))
+        posts[0].user?.should eq(nil)
+      end
+
       it "should set the foreign key when setting the object" do
         user = User.new
         user.name = "tester"

--- a/src/crecto/repo.cr
+++ b/src/crecto/repo.cr
@@ -709,6 +709,7 @@ module Crecto
 
     private def belongs_to_preload(results, queryable, preload)
       ids = results.map { |r| queryable.foreign_key_value_for_association(preload[:symbol], r) }
+      ids.compact!
       return if ids.empty?
       query = Crecto::Repo::Query.where(id: ids)
       if preload_query = preload[:query]
@@ -721,7 +722,7 @@ module Crecto
 
         results.each do |result|
           fkey = queryable.foreign_key_value_for_association(preload[:symbol], result)
-          if relation_items.has_key?(fkey)
+          if fkey && relation_items.has_key?(fkey)
             items = relation_items[fkey]
             queryable.set_value_for_association(preload[:symbol], result, items.map { |i| i.as(Crecto::Model) })
           end


### PR DESCRIPTION
fixes #195