### PR TITLE
Add Model.init_with macro for nicer creation

### DIFF
--- a/spec/model_spec.cr
+++ b/spec/model_spec.cr
@@ -7,6 +7,11 @@ describe Crecto::Model do
       user.name.should eq("test")
     end
 
+    it "can be instatiated with values" do
+      user = User.init_with(name: "test")
+      user.name.should eq("test")
+    end
+
     it "sets default values" do
       model = DefaultValue.from_json(%|{"default_string":"overridden"}|)
       model.default_string.should eq("overridden")

--- a/src/crecto/model.cr
+++ b/src/crecto/model.cr
@@ -114,10 +114,10 @@ module Crecto
     end
 
     macro init_with(**args)
-      {{@type}}.new.tap do |item|
+      {{@type}}.new.tap do |%item|
         {% for setter, value in args %}
           {% raise "#{@type} doesn't have a setter called '#{setter}'" unless @type.methods.map(&.name.stringify).includes?("#{setter}=") %}
-          item.{{setter.id}} = {{value}}
+          %item.{{setter.id}} = {{value}}
         {% end %}
       end
     end

--- a/src/crecto/model.cr
+++ b/src/crecto/model.cr
@@ -112,5 +112,14 @@ module Crecto
       def self.through_key_for_association(association : Symbol) : Symbol?
       end
     end
+
+    macro init_with(**args)
+      {{@type}}.new.tap do |item|
+        {% for setter, value in args %}
+          {% raise "#{@type} doesn't have a setter called '#{setter}'" unless @type.methods.map(&.name.stringify).includes?("#{setter}=") %}
+          item.{{setter.id}} = {{value}}
+        {% end %}
+      end
+    end
   end
 end


### PR DESCRIPTION
# Usage

```crystal
class User < Crecto::Model
  schema "users" do
    field :name, String
  end
end

user = User.init_with(name: "hello") # doesn't fail
user = User.init_with(other_param: "hello") # can't compile, `other_param=` isn't defined on a User instance!
```

## What it does actually

```crystal
User.init_with(one: "One!", two: "Two!")

# turns into

User.new.tap |__temp_89|
  __temp_89.one = "One!"
  __temp_89.two = "Two!"
end
```