### PR TITLE
Fixes #207. Handle single-column updates for postgres 10.x

### DIFF
--- a/spec/adapters/postgres_adapter_spec.cr
+++ b/spec/adapters/postgres_adapter_spec.cr
@@ -69,8 +69,7 @@ if Repo.config.adapter == Crecto::Adapters::Postgres
       changeset.instance.name = "snoopy"
       Repo.update(changeset.instance)
       check_sql do |sql|
-        sql.should eq(["UPDATE users SET (name, things, smallnum, nope, yep, some_date, pageviews, unique_field, created_at, updated_at, id) = \
-          ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) WHERE (id=$12) RETURNING *"])
+        sql.should eq(["UPDATE users SET name=$1, things=$2, smallnum=$3, nope=$4, yep=$5, some_date=$6, pageviews=$7, unique_field=$8, created_at=$9, updated_at=$10, id=$11 WHERE (id=$12) RETURNING *"])
       end
     end
 

--- a/src/crecto/adapters/base_adapter.cr
+++ b/src/crecto/adapters/base_adapter.cr
@@ -108,7 +108,7 @@ module Crecto
         q = String.build do |builder|
           builder <<
             "INSERT INTO " << changeset.instance.class.table_name <<
-            " (" << fields_values[:fields] << ')' <<
+            " (" << fields_values[:fields].join(", ") << ')' <<
             " VALUES" <<
             " ("
           fields_values[:values].size.times do
@@ -173,7 +173,7 @@ module Crecto
           joins(builder, queryable, query, params)
           wheres(builder, queryable, query, params)
           or_wheres(builder, queryable, query, params)
-          order_bys(builder, query) 
+          order_bys(builder, query)
           limit(builder, query)
           offset(builder, query)
           group_by(builder, query)
@@ -216,7 +216,7 @@ module Crecto
         q = String.build do |builder|
           delete_begin(builder, queryable.table_name)
 
-          wheres(builder, queryable, query, params) 
+          wheres(builder, queryable, query, params)
           or_wheres(builder, queryable, query, params)
         end
 

--- a/src/crecto/adapters/postgres_adapter.cr
+++ b/src/crecto/adapters/postgres_adapter.cr
@@ -7,14 +7,11 @@ module Crecto
       extend BaseAdapter
 
       private def self.update_begin(builder, table_name, fields_values)
-        builder << "UPDATE " << table_name << " SET ("
-        builder << fields_values[:fields] << ')'
-        builder << " = ("
-        fields_values[:values].size.times do
-          builder << "?, "
+        builder << "UPDATE " << table_name << " SET "
+        fields_values[:fields].each do |field_value|
+          builder << field_value << "=?, "
         end
         builder.back(2)
-        builder << ')'
       end
 
       private def self.update(conn, changeset)
@@ -41,7 +38,7 @@ module Crecto
             x.as(DbValue)
           end
         end
-        {fields: query_hash.keys.join(", "), values: values}
+        {fields: query_hash.keys, values: values}
       end
     end
   end


### PR DESCRIPTION
Solution based on this thread from the psql-bugs mailing list: https://www.postgresql.org/message-id/DzifLcHs-9wlp5kq6MPKTxu6zI8s5LhAEaVsrq_NRTuQTkw_EWrogrLgDhQ7i5W-cvaIPig0gH59FzBk7Lwr8FUvV7H0fLOYI8heueaoG1Y%3D%40protonmail.com

The issue here is that postgres 10 changed how queries are parsed, part of which made them more conformant to the SQL spec by requiring a properly-formed row value in UPDATE queries. This change mainly affects single-column row values, where it is now _invalid_ to specify a single column in a parentheses as a row value. Always providing `ROW` in the generated SQL should avoid this and be more future-proof.