### PR TITLE
don't change the type of int fields

### DIFF
--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -155,7 +155,7 @@ module Crecto
 
       {% mapping = CRECTO_FIELDS.map do |field|
            json_fields.push(field[:name]) if field[:type].id.stringify == "Json"
-           field_type = field[:type].id == "Int64" || field[:type].id == "Int32" ? "PkeyValue" : field[:type].id.stringify
+           field_type = field[:type].id.stringify
            "#{field[:name].id.stringify}: {type: #{field_type.id}, nilable: true}"
          end %}
 


### PR DESCRIPTION
fixes #226 

Any `Int64` or `Int32` fields were being cast to `PkeyValue`.  Its been this way for a while and I cant remember why I did this, but there is no way to know this implicit thing is happening and is probably incorrect.

After removing this cast all specs still pass and the issue where a JSON field comes back as a different type no longer happens.
