### PR TITLE
Make validate_required fail on empty string

### DIFF
--- a/spec/changeset_spec.cr
+++ b/spec/changeset_spec.cr
@@ -79,6 +79,13 @@ describe Crecto do
         changeset.errors.size.should be > 0
         changeset.errors[0].should eq({:field => "name", :message => "is required"})
       end
+
+      it "should have errors when symbol exists and is empty" do
+        u = UserRequired.new
+        u.name = ""
+        changeset = UserRequired.changeset(u)
+        changeset.errors.should contain({:field => "name", :message => "is required"})
+      end
     end
 
     describe "#validate_format" do

--- a/src/crecto/changeset/changeset.cr
+++ b/src/crecto/changeset/changeset.cr
@@ -104,7 +104,7 @@ module Crecto
       private def check_required!
         return unless REQUIRED_FIELDS.has_key?(@class_key)
         REQUIRED_FIELDS[@class_key].each do |field|
-          add_error(field.to_s, "is required") if @instance_hash[field].nil?
+          add_error(field.to_s, "is required") if @instance_hash[field].nil? || @instance_hash[field] == ""
         end
       end
 


### PR DESCRIPTION
Pull request for issue #237 . This implements the validate_required for empty_strings - so when an empty string is used for an attribute that is required it will fail the validation.

I have not implemented trim: true functionality yet as it requires a lot more work.