### PR TITLE
Fix has_many; update deps

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,12 +13,12 @@ dependencies:
 development_dependencies:
   mysql:
     github: crystal-lang/crystal-mysql
-    version: 0.11.0
+    version: ~> 0.11.1
 
   pg:
     github: will/crystal-pg
-    version: 0.21.0
+    version: ~> 0.21.1
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: 0.16.0
+    version: ~> 0.16.0

--- a/src/crecto/schema/has_many.cr
+++ b/src/crecto/schema/has_many.cr
@@ -46,7 +46,7 @@ module Crecto
           foreign_key: {{foreign_key.id.symbolize}},
           foreign_key_value: ->(item : Crecto::Model){
             {% if opts[:through] %}
-              item.as({{klass}}).id
+              item.as({{klass}}).id.as(PkeyValue)
             {% else %}
               item.as({{klass}}).{{foreign_key.id}}.as(PkeyValue)
             {% end %}


### PR DESCRIPTION
2 changes. First of all, `has_many` associations were not working. I don't know if this was due to the 0.35.0 update or not, but it seems like the foreign key value needs to be cast to `PkeyValue` no matter what it is.

The second change is just updating the dependencies. I also added the `~>` so that we get patches.