### PR TITLE
Major overhaul

### DIFF
--- a/src/crecto.cr
+++ b/src/crecto.cr
@@ -5,6 +5,7 @@ require "./crecto/adapters/*"
 require "./crecto/changeset/*"
 require "./crecto/repo/*"
 require "./crecto/*"
+require "./crecto/converters/*"
 
 module Crecto
 end

--- a/src/crecto/adapters/base_adapter.cr
+++ b/src/crecto/adapters/base_adapter.cr
@@ -7,20 +7,20 @@ module Crecto
       #
       # Query data store using a *query*
       #
-      def run(conn : DB::Database | DB::Transaction, operation : Symbol, queryable, query : Crecto::Repo::Query)
-        case operation
-        when :all
+      def run(conn : DB::Database | DB::Transaction, operation : String | Symbol, queryable, query : Crecto::Repo::Query)
+        case operation.to_s
+        when "all"
           all(conn, queryable, query)
-        when :delete_all
+        when "delete_all"
           delete(conn, queryable, query)
         else
           raise Exception.new("invalid operation passed to run")
         end
       end
 
-      def run(conn : DB::Database | DB::Transaction, operation : Symbol, queryable, query : Crecto::Repo::Query, query_hash : Hash)
-        case operation
-        when :update_all
+      def run(conn : DB::Database | DB::Transaction, operation : String | Symbol, queryable, query : Crecto::Repo::Query, query_hash : Hash)
+        case operation.to_s
+        when "update_all"
           update(conn, queryable, query, query_hash)
         else
           raise Exception.new("invalid operation passed to run")
@@ -30,9 +30,9 @@ module Crecto
       #
       # Query data store using an *id*, returning a single record.
       #
-      def run(conn : DB::Database | DB::Transaction, operation : Symbol, queryable, id : PkeyValue)
-        case operation
-        when :get
+      def run(conn : DB::Database | DB::Transaction, operation : String | Symbol, queryable, id : PkeyValue)
+        case operation.to_s
+        when "get"
           get(conn, queryable, id)
         else
           raise Exception.new("invalid operation passed to run")
@@ -42,9 +42,9 @@ module Crecto
       #
       # Query data store using *sql*, returning multiple rows
       #
-      def run(conn : DB::Database | DB::Transaction, operation : Symbol, sql : String, params : Array(DbValue))
-        case operation
-        when :sql
+      def run(conn : DB::Database | DB::Transaction, operation : String | Symbol, sql : String, params : Array(DbValue))
+        case operation.to_s
+        when "sql"
           execute(conn, position_args(sql), params)
         else
           raise Exception.new("invalid operation passed to run")
@@ -53,12 +53,12 @@ module Crecto
 
       # Query data store in relation to a *queryable_instance* of Schema
       def run_on_instance(conn : DB::Database | DB::Transaction, operation, changeset)
-        case operation
-        when :insert
+        case operation.to_s
+        when "insert"
           insert(conn, changeset)
-        when :update
+        when "update"
           update(conn, changeset)
-        when :delete
+        when "delete"
           delete(conn, changeset)
         else
           raise Exception.new("invalid operation passed to run_on_instance")
@@ -348,7 +348,7 @@ module Crecto
 
       private def join_through(builder, queryable, join)
         association_klass = queryable.klass_for_association(join)
-        join_klass = queryable.klass_for_association(queryable.through_key_for_association(join).as(Symbol))
+        join_klass = queryable.klass_for_association(queryable.through_key_for_association(join).as(String))
         return "" if join_klass.nil? || association_klass.nil?
 
         builder << " INNER JOIN " << join_klass.table_name << " ON "

--- a/src/crecto/changeset.cr
+++ b/src/crecto/changeset.cr
@@ -9,21 +9,21 @@ module Crecto
     private alias ArrayOfAny = Array(String) | Array(Int32) | Array(Int64) | Array(Time) | Array(Int32 | Int64 | String | Bool | Float64 | Time)
 
     # :nodoc:
-    REQUIRED_FIELDS = {} of String => Array(Symbol)
+    REQUIRED_FIELDS = {} of String => Array(String)
     # :nodoc:
-    REQUIRED_FORMATS = {} of String => Array({field: Symbol, pattern: Regex})
+    REQUIRED_FORMATS = {} of String => Array({field: String, pattern: Regex})
     # :nodoc:
-    REQUIRED_ARRAY_INCLUSIONS = {} of String => Array({field: Symbol, in: ArrayOfAny})
+    REQUIRED_ARRAY_INCLUSIONS = {} of String => Array({field: String, in: ArrayOfAny})
     # :nodoc:
-    REQUIRED_RANGE_INCLUSIONS = {} of String => Array({field: Symbol, in: RangeTypes})
+    REQUIRED_RANGE_INCLUSIONS = {} of String => Array({field: String, in: RangeTypes})
     # :nodoc:
-    REQUIRED_ARRAY_EXCLUSIONS = {} of String => Array({field: Symbol, in: ArrayOfAny})
+    REQUIRED_ARRAY_EXCLUSIONS = {} of String => Array({field: String, in: ArrayOfAny})
     # :nodoc:
-    REQUIRED_RANGE_EXCLUSIONS = {} of String => Array({field: Symbol, in: RangeTypes})
+    REQUIRED_RANGE_EXCLUSIONS = {} of String => Array({field: String, in: RangeTypes})
     # :nodoc:
-    REQUIRED_LENGTHS = {} of String => Array({field: Symbol, is: Int32 | Nil, min: Int32 | Nil, max: Int32 | Nil})
+    REQUIRED_LENGTHS = {} of String => Array({field: String, is: Int32 | Nil, min: Int32 | Nil, max: Int32 | Nil})
     # :nodoc:
-    UNIQUE_FIELDS = {} of String => Array(Symbol)
+    UNIQUE_FIELDS = {} of String => Array(String)
 
     macro extended
       # :nodoc:
@@ -45,78 +45,78 @@ module Crecto
     end
 
     # Validate that a *field* is present.
-    def validate_required(field : Symbol)
-      REQUIRED_FIELDS[self.to_s] = [] of Symbol unless REQUIRED_FIELDS.has_key?(self.to_s)
-      REQUIRED_FIELDS[self.to_s].push(field)
+    def validate_required(field : String | Symbol)
+      REQUIRED_FIELDS[self.to_s] = [] of String unless REQUIRED_FIELDS.has_key?(self.to_s)
+      REQUIRED_FIELDS[self.to_s].push(field.to_s)
     end
 
     # Validates that an array of *fields* is present.
-    def validate_required(fields : Array(Symbol))
+    def validate_required(fields : Array(String | Symbol))
       fields.each { |f| validate_required(f) }
     end
 
     # Validate the format for the value of *field* using a *pattern*
-    def validate_format(field : Symbol, pattern : Regex)
-      REQUIRED_FORMATS[self.to_s] = [] of {field: Symbol, pattern: Regex} unless REQUIRED_FORMATS.has_key?(self.to_s)
-      REQUIRED_FORMATS[self.to_s].push({field: field, pattern: pattern})
+    def validate_format(field : String | Symbol, pattern : Regex)
+      REQUIRED_FORMATS[self.to_s] = [] of {field: String, pattern: Regex} unless REQUIRED_FORMATS.has_key?(self.to_s)
+      REQUIRED_FORMATS[self.to_s].push({field: field.to_s, pattern: pattern})
     end
 
     # Validate the format for an array of *fields* values using a *pattern*
-    def validate_format(fields : Array(Symbol), pattern : Regex)
+    def validate_format(fields : Array(String | Symbol), pattern : Regex)
       fields.each { |field| validate_format(field, pattern) }
     end
 
-    def validate_inclusion(field : Symbol, args : Hash(Symbol, (ArrayOfAny | RangeTypes)))
-      raise "Missing :in argument" unless args.has_key?(:in)
+    def validate_inclusion(field : String | Symbol, args : Hash(String, (ArrayOfAny | RangeTypes)))
+      raise "Missing :in argument" unless args.has_key?("in")
       validate_inclusion(field, args[:in])
     end
 
-    def validate_inclusion(fields : Array(Symbol), args : Hash(Symbol, (ArrayOfAny | RangeTypes)))
-      raise "Missing :in argument" unless args.has_key?(:in)
+    def validate_inclusion(fields : Array(String | Symbol), args : Hash(String, (ArrayOfAny | RangeTypes)))
+      raise "Missing :in argument" unless args.has_key?("in")
       validate_inclusion(fields, args[:in])
     end
 
     # Validate the inclusion of *field* value is in *inside*
-    def validate_inclusion(field : Symbol, inside : Array)
-      REQUIRED_ARRAY_INCLUSIONS[self.to_s] = [] of {field: Symbol, in: ArrayOfAny} unless REQUIRED_ARRAY_INCLUSIONS.has_key?(self.to_s)
-      REQUIRED_ARRAY_INCLUSIONS[self.to_s].push({field: field, in: inside})
+    def validate_inclusion(field : String | Symbol, inside : Array)
+      REQUIRED_ARRAY_INCLUSIONS[self.to_s] = [] of {field: String, in: ArrayOfAny} unless REQUIRED_ARRAY_INCLUSIONS.has_key?(self.to_s)
+      REQUIRED_ARRAY_INCLUSIONS[self.to_s].push({field: field.to_s, in: inside})
     end
 
     # Validate the inclusion of *field* value is in *inside*
-    def validate_inclusion(field : Symbol, inside : RangeTypes)
-      REQUIRED_RANGE_INCLUSIONS[self.to_s] = [] of {field: Symbol, in: RangeTypes} unless REQUIRED_RANGE_INCLUSIONS.has_key?(self.to_s)
-      REQUIRED_RANGE_INCLUSIONS[self.to_s].push({field: field, in: inside})
+    def validate_inclusion(field : String | Symbol, inside : RangeTypes)
+      REQUIRED_RANGE_INCLUSIONS[self.to_s] = [] of {field: String, in: RangeTypes} unless REQUIRED_RANGE_INCLUSIONS.has_key?(self.to_s)
+      REQUIRED_RANGE_INCLUSIONS[self.to_s].push({field: field.to_s, in: inside})
     end
 
     # Validate the inclusion of *fields* values is in *inside*
-    def validate_inclusion(fields : Array(Symbol), inside : Array | Range)
-      fields.each { |field| validate_inclusion(field, inside) }
+    def validate_inclusion(fields : Array(String | Symbol), inside : Array | Range)
+      fields.each { |field| validate_inclusion(field.to_s, inside) }
     end
 
-    def validate_exclusion(field : Symbol, args : Hash(Symbol, (ArrayOfAny | RangeTypes)))
-      raise "Missing :in argument" unless args.has_key?(:in)
+    def validate_exclusion(field : String | Symbol, args : Hash(String, (ArrayOfAny | RangeTypes)))
+      raise "Missing :in argument" unless args.has_key?("in")
       validate_exclusion(field, args[:in])
     end
 
-    def validate_exclusion(fields : Array(Symbol), args : Hash(Symbol, (ArrayOfAny | RangeTypes)))
-      raise "Missing :in argument" unless args.has_key?(:in)
+    def validate_exclusion(fields : Array(String | Symbol), args : Hash(String, (ArrayOfAny | RangeTypes)))
+      raise "Missing :in argument" unless args.has_key?("in")
       validate_exclusion(fields, args[:in])
     end
 
     # Validate the inclusion of *field* value is not in *inside*
-    def validate_exclusion(field : Symbol, inside : Array)
-      REQUIRED_ARRAY_EXCLUSIONS[self.to_s] = [] of {field: Symbol, in: ArrayOfAny} unless REQUIRED_ARRAY_EXCLUSIONS.has_key?(self.to_s)
-      REQUIRED_ARRAY_EXCLUSIONS[self.to_s].push({field: field, in: inside})
+    def validate_exclusion(field : String | Symbol, inside : Array)
+      REQUIRED_ARRAY_EXCLUSIONS[self.to_s] = [] of {field: String, in: ArrayOfAny} unless REQUIRED_ARRAY_EXCLUSIONS.has_key?(self.to_s)
+      REQUIRED_ARRAY_EXCLUSIONS[self.to_s].push({field: field.to_s, in: inside})
     end
 
     # Validate the inclusion of *field* value is not in *inside*
-    def validate_exclusion(field : Symbol, inside : RangeTypes)
+    def validate_exclusion(field : String | Symbol, inside : RangeTypes)
       REQUIRED_RANGE_EXCLUSIONS[self.to_s] = [] of {field: Symbol, in: RangeTypes} unless REQUIRED_RANGE_EXCLUSIONS.has_key?(self.to_s)
-      REQUIRED_RANGE_EXCLUSIONS[self.to_s].push({field: field, in: inside})
+      REQUIRED_RANGE_EXCLUSIONS[self.to_s].push({field: field.to_s, in: inside})
     end
 
     # Validate the inclusion of *fields* values is not *inside*
-    def validate_exclusion(fields : Array(Symbol), inside : Array | Range)
+    def validate_exclusion(fields : Array(String | Symbol), inside : Array | Range)
       fields.each { |field| validate_exclusion(field, inside) }
     end
 
@@ -126,9 +126,9 @@ module Crecto
     # * min: Int32
     # * max: Int32
     #
-    def validate_length(field : Symbol, **opts)
-      REQUIRED_LENGTHS[self.to_s] = [] of {field: Symbol, is: Int32?, min: Int32?, max: Int32?} unless REQUIRED_LENGTHS.has_key?(self.to_s)
-      REQUIRED_LENGTHS[self.to_s].push({field: field, is: opts[:is]?, min: opts[:min]?, max: opts[:max]?})
+    def validate_length(field : String | Symbol, **opts)
+      REQUIRED_LENGTHS[self.to_s] = [] of {field: String, is: Int32?, min: Int32?, max: Int32?} unless REQUIRED_LENGTHS.has_key?(self.to_s)
+      REQUIRED_LENGTHS[self.to_s].push({field: field.to_s, is: opts[:is]?, min: opts[:min]?, max: opts[:max]?})
     end
 
     # Validate the length of *fields* value using the following opts:
@@ -137,7 +137,7 @@ module Crecto
     # * min: Int32
     # * max: Int32
     #
-    def validate_length(fields : Array(Symbol), **opts)
+    def validate_length(fields : Array(String | Symbol), **opts)
       fields.each { |field| validate_length(field, **opts) }
     end
 
@@ -154,13 +154,13 @@ module Crecto
     end
 
     # Catches unique constraint database errors for *field* and converts them to changeset errors
-    def unique_constraint(field : Symbol)
-      UNIQUE_FIELDS[self.to_s] = [] of Symbol unless UNIQUE_FIELDS.has_key?(self.to_s)
-      UNIQUE_FIELDS[self.to_s].push(field)
+    def unique_constraint(field : String | Symbol)
+      UNIQUE_FIELDS[self.to_s] = [] of String unless UNIQUE_FIELDS.has_key?(self.to_s)
+      UNIQUE_FIELDS[self.to_s].push(field.to_s)
     end
 
     # Catches unique constraint database errors for all *fields* and converts them to changeset errors
-    def unique_constraint(fields : Array(Symbol))
+    def unique_constraint(fields : Array(String | Symbol))
       fields.each { |f| unique_constraint(f) }
     end
 

--- a/src/crecto/changeset/changeset.cr
+++ b/src/crecto/changeset/changeset.cr
@@ -16,17 +16,17 @@ module Crecto
     #
     class Changeset(T)
       # :nodoc:
-      property action : Symbol?
+      property action : String?
       # :nodoc:
-      property errors = [] of Hash(Symbol, String)
+      property errors = [] of NamedTuple(field: String, message: String)
       # :nodoc:
-      property changes = [] of Hash(Symbol, DbValue | ArrayDbValue)
+      property changes = [] of Hash(String, DbValue | ArrayDbValue)
       # :nodoc:
-      property source : Hash(Symbol, DbValue)? | Hash(Symbol, ArrayDbValue)?
+      property source : Hash(String, DbValue)? | Hash(String, ArrayDbValue)?
 
       private property valid = true
       private property class_key : String?
-      private property instance_hash : Hash(Symbol, DbValue | ArrayDbValue)
+      private property instance_hash : Hash(String, DbValue | ArrayDbValue)
 
       def initialize(@instance : T)
         @class_key = @instance.class.to_s
@@ -54,7 +54,7 @@ module Crecto
       end
 
       def add_error(key, val)
-        errors.push({:field => key, :message => val})
+        errors.push({field: key, message: val})
         @valid = false
       end
 
@@ -182,7 +182,7 @@ module Crecto
       end
 
       private def diff_from_initial_values!
-        @initial_values = {} of Symbol => (DbValue | ArrayDbValue) if @initial_values.nil?
+        @initial_values = {} of String => (DbValue | ArrayDbValue) if @initial_values.nil?
         @changes.clear
         @instance_hash.each do |field, value|
           @changes.push({field => value}) if @initial_values.as(Hash).fetch(field, nil) != value

--- a/src/crecto/converter.cr
+++ b/src/crecto/converter.cr
@@ -1,0 +1,6 @@
+module Crecto
+  module Converter(T)
+    abstract def to_rs(item : T)
+    abstract def from_rs(rs : DB::ResultSet) : T
+  end
+end

--- a/src/crecto/converters/enum_int_converter.cr
+++ b/src/crecto/converters/enum_int_converter.cr
@@ -1,0 +1,13 @@
+module Crecto
+  class EnumIntConverter(T)
+    include Converter(T)
+
+    def to_rs(item : T)
+      item.to_i.as(DbValue)
+    end
+
+    def from_rs(rs : DB::ResultSet) : T
+      T.from_value(rs.read(Int))
+    end
+  end
+end

--- a/src/crecto/converters/enum_string_converter.cr
+++ b/src/crecto/converters/enum_string_converter.cr
@@ -1,0 +1,13 @@
+module Crecto
+  class EnumStringConverter(T)
+    include Converter(T)
+
+    def to_rs(item : T)
+      item.to_s.as(DbValue)
+    end
+
+    def from_rs(rs : DB::ResultSet) : T
+      T.parse(rs.read(String))
+    end
+  end
+end

--- a/src/crecto/model.cr
+++ b/src/crecto/model.cr
@@ -18,9 +18,9 @@ module Crecto
       include Crecto::Schema::BelongsTo
       extend Crecto::Changeset({{@type}})
 
-      CRECTO_DESTROY_ASSOCIATIONS = Array(Symbol).new
-      CRECTO_NULLIFY_ASSOCIATIONS = Array(Symbol).new
-      CRECTO_MODEL_FIELDS = [] of NamedTuple(name: Symbol, type: String)
+      CRECTO_DESTROY_ASSOCIATIONS = Array(String).new
+      CRECTO_NULLIFY_ASSOCIATIONS = Array(String).new
+      CRECTO_MODEL_FIELDS = [] of NamedTuple(name: String, type: String)
 
       def self.use_primary_key?
         CRECTO_USE_PRIMARY_KEY
@@ -47,12 +47,12 @@ module Crecto
       end
 
       # Class variables
-      @@changeset_fields = [] of Symbol
-      @@initial_values = {} of Symbol => DbValue
+      @@changeset_fields = [] of String
+      @@initial_values = {} of String => DbValue
 
       # Instance properties
       @[JSON::Field(ignore: true)]
-      property initial_values : Hash(Symbol, DbValue)?
+      property initial_values : Hash(String, DbValue)?
 
       def initialize
       end
@@ -60,11 +60,6 @@ module Crecto
       # Return the primary key field as a String
       def self.primary_key_field
         CRECTO_PRIMARY_KEY_FIELD
-      end
-
-      # Return the primary key field as a Symbol
-      def self.primary_key_field_symbol
-        CRECTO_PRIMARY_KEY_FIELD_SYMBOL
       end
 
       def self.created_at_field
@@ -91,25 +86,25 @@ module Crecto
 
       # Empty association methods
       # Implementations are in the setup_association macro
-      def self.klass_for_association(association : Symbol)
+      def self.klass_for_association(association : String | Symbol)
       end
 
-      def self.foreign_key_for_association(association : Symbol) : Symbol?
+      def self.foreign_key_for_association(association : String | Symbol) : String?
       end
 
       def self.foreign_key_for_association(klass : Crecto::Model.class)
       end
 
-      def self.foreign_key_value_for_association(association : Symbol, item)
+      def self.foreign_key_value_for_association(association : String | Symbol, item)
       end
 
-      def self.set_value_for_association(association : Symbol, item, items)
+      def self.set_value_for_association(association : String | Symbol, item, items)
       end
 
-      def self.association_type_for_association(association : Symbol)
+      def self.association_type_for_association(association : String | Symbol)
       end
 
-      def self.through_key_for_association(association : Symbol) : Symbol?
+      def self.through_key_for_association(association : String | Symbol) : String?
       end
 
       # Class methods for mass assignment
@@ -121,11 +116,7 @@ module Crecto
         new.tap { |m| m.cast(attributes, whitelist) }
       end
 
-      def self.cast(attributes : Hash(Symbol, T), whitelist : Array(Symbol) = attributes.keys) forall T
-        new.tap { |m| m.cast(attributes, whitelist) }
-      end
-
-      def self.cast(attributes : Hash(String, T), whitelist : Array(String) = attributes.keys) forall T
+      def self.cast(attributes : Hash(String, T), whitelist : Array(String | Symbol) = attributes.keys) forall T
         new.tap { |m| m.cast(attributes, whitelist) }
       end
 
@@ -146,16 +137,13 @@ module Crecto
       def cast(attributes : NamedTuple, whitelist : Tuple = attributes.keys)
       end
 
-      def cast(attributes : Hash(Symbol, T), whitelist : Array(Symbol) = attributes.keys) forall T
-      end
-
-      def cast(attributes : Hash(String, T), whitelist : Array(String) = attributes.keys) forall T
+      def cast(attributes : Hash(String | Symbol, T), whitelist : Array(String | Symbol) = attributes.keys) forall T
       end
 
       # Instance method for compile-time type safe mass assignment
       def cast!(**attributes : **T) forall T
         \{% for key in T.keys %}
-           self.\{{ key }} = attributes[\{{ key.symbolize }}]
+           self.\{{ key }} = attributes[\{{ key.stringify }}]
         \{% end %}
       end
 

--- a/src/crecto/multi.cr
+++ b/src/crecto/multi.cr
@@ -8,7 +8,7 @@ module Crecto
   #
   class Multi
     # :nodoc:
-    property errors = Array(Hash(Symbol, String)).new
+    property errors = Array(Hash(String, String)).new
     # :nodoc:
     record Insert, instance : Crecto::Model
     # :nodoc:
@@ -19,18 +19,18 @@ module Crecto
     record Update, instance : Crecto::Model
 
     # :nodoc:
-    alias UpdateHash = Hash(Symbol, PkeyValue) |
-                       Hash(Symbol, DbValue) |
-                       Hash(Symbol, Array(DbValue)) |
-                       Hash(Symbol, Array(PkeyValue)) |
-                       Hash(Symbol, Array(Int32)) |
-                       Hash(Symbol, Array(Int64)) |
-                       Hash(Symbol, Array(String)) |
-                       Hash(Symbol, Int32 | String) |
-                       Hash(Symbol, Int32) |
-                       Hash(Symbol, Int64) |
-                       Hash(Symbol, String) |
-                       Hash(Symbol, Int32 | Int64 | String | Nil)
+    alias UpdateHash = Hash(String, PkeyValue) |
+                       Hash(String, DbValue) |
+                       Hash(String, Array(DbValue)) |
+                       Hash(String, Array(PkeyValue)) |
+                       Hash(String, Array(Int32)) |
+                       Hash(String, Array(Int64)) |
+                       Hash(String, Array(String)) |
+                       Hash(String, Int32 | String) |
+                       Hash(String, Int32) |
+                       Hash(String, Int64) |
+                       Hash(String, String) |
+                       Hash(String, Int32 | Int64 | String | Nil)
 
     # :nodoc:
     record UpdateAll, queryable : Crecto::Model.class, query : Crecto::Repo::Query, update_hash : UpdateHash

--- a/src/crecto/repo/config.cr
+++ b/src/crecto/repo/config.cr
@@ -68,8 +68,8 @@ module Crecto
 
       private def set_url_creds(io)
         return if adapter == Crecto::Adapters::SQLite3
-        io << URI.encode(username) unless username.empty?
-        io << ":#{URI.encode(password)}" unless password.empty?
+        io << URI.encode_path(username) unless username.empty?
+        io << ":#{URI.encode_path(password)}" unless password.empty?
         io << "@" unless username.empty?
       end
 

--- a/src/crecto/schema.cr
+++ b/src/crecto/schema.cr
@@ -39,8 +39,6 @@ module Crecto
     # :nodoc:
     CRECTO_USE_PRIMARY_KEY = true
     # :nodoc:
-    CRECTO_PRIMARY_KEY_FIELD_SYMBOL = :id
-    # :nodoc:
     CRECTO_PRIMARY_KEY_FIELD_TYPE = "PkeyValue"
 
     # schema block macro
@@ -55,9 +53,8 @@ module Crecto
 
       # macro constants
       CRECTO_VALID_FIELD_TYPES = [String, Int64, Int32, Int16, Float32, Float64, Bool, Time, Int32 | Int64, Float32 | Float64, Json, PkeyValue, Array(String), Array(Int64), Array(Int32), Array(Int16), Array(Float32), Array(Float64), Array(Bool), Array(Time), Array(Int32 | Int64), Array(Float32 | Float64), Array(Json), Array(PkeyValue)]
-      CRECTO_VALID_FIELD_OPTIONS = [:primary_key, :virtual, :default]
-      CRECTO_FIELDS      = [] of NamedTuple(name: Symbol, type: String)
-      CRECTO_ENUM_FIELDS = [] of NamedTuple(name: Symbol, type: String, column_name: String, column_type: String)
+      CRECTO_VALID_FIELD_OPTIONS = [:primary_key, :virtual, :default, :converter]
+      CRECTO_FIELDS      = [] of NamedTuple(name: String, type: String, converter: Converter?)
 
       # Class variables
       @@table_name = {{table_name.id.stringify}}
@@ -68,7 +65,13 @@ module Crecto
     end
 
     # Field definitions macro
-    macro field(field_name, field_type, **opts)
+    macro field(field, **opts)
+      {%
+        field_name = field.var
+        field_type = field.type
+        default_value = field.value.nil? ? opts[:default] : field.value
+      %}
+
       # validate field options
       {% for opt in opts %}
         {% unless CRECTO_VALID_FIELD_OPTIONS.includes?(opt.id.symbolize) %}
@@ -82,7 +85,6 @@ module Crecto
 
       {% if opts.keys.includes?(:primary_key.id) %}
         CRECTO_PRIMARY_KEY_FIELD = {{field_name.id.stringify}}
-        CRECTO_PRIMARY_KEY_FIELD_SYMBOL = {{field_name.id.symbolize}}
         CRECTO_PRIMARY_KEY_FIELD_TYPE = {{field_type.id.stringify}}
         {% primary_key = true %}
       {% end %}
@@ -91,42 +93,28 @@ module Crecto
         {% virtual = true %}
       {% end %}
 
-      {% if opts.keys.includes?(:default.id) %}
-        @{{field_name.id}} = {{opts[:default]}}
-      {% else %}
+      {% if default_value.is_a?(NilLiteral) %}
         @{{field_name.id}} : {{field_type.id}}?
+      {% else %}
+        @{{field_name.id}} = {{default_value}}
       {% end %}
 
-      check_type!({{field_name}}, {{field_type}})
+
+      {% unless opts[:converter] %}
+        check_type!({{field_name.id.stringify}}, {{field_type}})
+      {% end %}
 
       # cache fields in class variable and macro variable
       {% unless virtual %}
-        @@changeset_fields << {{field_name}}
+        @@changeset_fields << {{field_name.id.stringify}}
       {% end %}
 
       {% unless primary_key %}
-        {% CRECTO_FIELDS.push({name: field_name, type: field_type}) %}
+        {% CRECTO_FIELDS.push({name: field_name.id.stringify, type: field_type.id.stringify, converter: opts[:converter]}) %}
         {% unless virtual %}
-          CRECTO_MODEL_FIELDS.push({name: {{field_name}}, type: {{field_type.id.stringify}}})
+          CRECTO_MODEL_FIELDS.push({name: {{field_name.id.stringify}}, type: {{field_type.id.stringify}}})
         {% end %}
       {% end %}
-    end
-
-    # Enum field definition macro.
-    # `opts` can include `column_name` to set the name of the backing column
-    # in the database and `column_type` to set the type of that column (String
-    # and all Int types are currently supported)
-    macro enum_field(field_name, field_type, **opts)
-      {%
-        column_type = String
-        column_type = opts[:column_type] if opts[:column_type]
-        column_name = "#{field_name.id}_#{column_type.id.stringify.downcase.id}"
-        column_name = opts[:column_name] if opts[:column_name]
-      %}
-
-      field({{column_name.id.symbolize}}, {{column_type}})
-
-      {% CRECTO_ENUM_FIELDS.push({name: field_name, type: field_type, column_name: column_name, column_type: column_type}) %}
     end
 
     # Macro to change created_at field name
@@ -142,7 +130,7 @@ module Crecto
     # :nodoc:
     macro check_type!(field_name, field_type)
       {% unless CRECTO_VALID_FIELD_TYPES.includes?(field_type) %}
-        raise Crecto::InvalidType.new("{{field_name}} type must be one of #{CRECTO_VALID_FIELD_TYPES.join(", ")}")
+        raise Crecto::InvalidType.new("{{field_name.id}} type must be one of #{CRECTO_VALID_FIELD_TYPES.join(", ")}")
       {% end %}
     end
 
@@ -156,23 +144,27 @@ module Crecto
       {% mapping = CRECTO_FIELDS.map do |field|
            json_fields.push(field[:name]) if field[:type].id.stringify == "Json"
            field_type = field[:type].id.stringify
-           "#{field[:name].id.stringify}: {type: #{field_type.id}, nilable: true}"
+           if field[:converter]
+            "#{field[:name].id.stringify}: {type: #{field_type.id}, nilable: true, converter: #{field[:converter]}.new}"
+           else
+            "#{field[:name].id.stringify}: {type: #{field_type.id}, nilable: true}"
+           end
          end %}
 
       {% if CRECTO_USE_PRIMARY_KEY %}
         {% mapping.push(CRECTO_PRIMARY_KEY_FIELD.id.stringify + ": {type: #{CRECTO_PRIMARY_KEY_FIELD_TYPE.id}, nilable: true}") %}
-        CRECTO_MODEL_FIELDS.push({name: {{CRECTO_PRIMARY_KEY_FIELD.id.symbolize}}, type: {{CRECTO_PRIMARY_KEY_FIELD_TYPE}}})
-        unique_constraint(CRECTO_PRIMARY_KEY_FIELD_SYMBOL)
+        CRECTO_MODEL_FIELDS.push({name: {{CRECTO_PRIMARY_KEY_FIELD.id.stringify}}, type: {{CRECTO_PRIMARY_KEY_FIELD_TYPE}}})
+        unique_constraint(CRECTO_PRIMARY_KEY_FIELD)
       {% end %}
 
       {% unless CRECTO_CREATED_AT_FIELD == nil %}
         {% mapping.push(CRECTO_CREATED_AT_FIELD.id.stringify + ": {type: Time, nilable: true}") %}
-        CRECTO_MODEL_FIELDS.push({name: {{CRECTO_CREATED_AT_FIELD.id.symbolize}}, type: "Time"})
+        CRECTO_MODEL_FIELDS.push({name: {{CRECTO_CREATED_AT_FIELD.id.stringify}}, type: "Time"})
       {% end %}
 
       {% unless CRECTO_UPDATED_AT_FIELD == nil %}
         {% mapping.push(CRECTO_UPDATED_AT_FIELD.id.stringify + ": {type: Time, nilable: true}") %}
-        CRECTO_MODEL_FIELDS.push({name: {{CRECTO_UPDATED_AT_FIELD.id.symbolize}}, type: "Time"})
+        CRECTO_MODEL_FIELDS.push({name: {{CRECTO_UPDATED_AT_FIELD.id.stringify}}, type: "Time"})
       {% end %}
 
       DB.mapping({ {{mapping.uniq.join(", ").id}} }, false)
@@ -190,63 +182,38 @@ module Crecto
         end
       {% end %}
 
-      {% for enum_field in CRECTO_ENUM_FIELDS %}
-        {%
-          field_name = enum_field[:name].id
-          field_type = enum_field[:type].id
-          column_name = enum_field[:column_name].id
-          column_type = enum_field[:column_type].id
-        %}
-        {% if column_type.stringify == "String" %}
-          def {{field_name}} : {{field_type}}
-            @{{field_name}} ||= {{field_type}}.parse(@{{column_name}}.to_s)
-          end
-
-          def {{field_name}}=(val : {{field_type}})
-            @{{field_name}} = val
-            @{{column_name}} = val.to_s
-          end
-
-        {% elsif column_type.stringify.includes?("Int") %}
-          def {{field_name}} : {{field_type}}
-            @{{field_name}} ||= {{field_type}}.new(@{{column_name}}.not_nil!.to_i32)
-          end
-
-          def {{field_name}}=(val : {{field_type}})
-            @{{field_name}} = val
-            @{{column_name}} = val.value
-          end
-        {% end %}
-      {% end %}
-
-
       # Builds a hash from all `CRECTO_FIELDS` defined
       def to_query_hash(include_virtual=false)
-        query_hash = {} of Symbol => DbValue | ArrayDbValue
+        query_hash = {} of String => DbValue | ArrayDbValue
 
         {% for field in CRECTO_FIELDS %}
           if include_virtual || @@changeset_fields.includes?({{field[:name]}})
+            {% if field[:converter] %}
+            converter = {{ field[:converter] }}.new
+            query_hash[{{field[:name]}}] = self.{{field[:name].id}} ? converter.to_rs(self.{{field[:name].id}}!) : nil
+            {% else %}
             query_hash[{{field[:name]}}] = self.{{field[:name].id}}
             query_hash[{{field[:name]}}] = query_hash[{{field[:name]}}].as(Time).to_utc if query_hash[{{field[:name]}}].is_a?(Time) && query_hash[{{field[:name]}}].as(Time).local?
+            {% end %}
           end
         {% end %}
 
         {% unless CRECTO_CREATED_AT_FIELD == nil %}
-          query_hash[{{CRECTO_CREATED_AT_FIELD.id.symbolize}}] = self.{{CRECTO_CREATED_AT_FIELD.id}}.nil? ? nil : (self.{{CRECTO_CREATED_AT_FIELD.id}}.as(Time).local? ? self.{{CRECTO_CREATED_AT_FIELD.id}}.as(Time).to_utc : self.{{CRECTO_CREATED_AT_FIELD.id}})
+          query_hash[{{CRECTO_CREATED_AT_FIELD.id.stringify}}] = self.{{CRECTO_CREATED_AT_FIELD.id}}.nil? ? nil : (self.{{CRECTO_CREATED_AT_FIELD.id}}.as(Time).local? ? self.{{CRECTO_CREATED_AT_FIELD.id}}.as(Time).to_utc : self.{{CRECTO_CREATED_AT_FIELD.id}})
         {% end %}
 
         {% unless CRECTO_UPDATED_AT_FIELD == nil %}
-          query_hash[{{CRECTO_UPDATED_AT_FIELD.id.symbolize}}] = self.{{CRECTO_UPDATED_AT_FIELD.id}}.nil? ? nil : (self.{{CRECTO_UPDATED_AT_FIELD.id}}.as(Time).local? ? self.{{CRECTO_UPDATED_AT_FIELD.id}}.as(Time).to_utc : self.{{CRECTO_UPDATED_AT_FIELD.id}})
+          query_hash[{{CRECTO_UPDATED_AT_FIELD.id.stringify}}] = self.{{CRECTO_UPDATED_AT_FIELD.id}}.nil? ? nil : (self.{{CRECTO_UPDATED_AT_FIELD.id}}.as(Time).local? ? self.{{CRECTO_UPDATED_AT_FIELD.id}}.as(Time).to_utc : self.{{CRECTO_UPDATED_AT_FIELD.id}})
         {% end %}
 
         {% if CRECTO_USE_PRIMARY_KEY %}
-          query_hash[{{CRECTO_PRIMARY_KEY_FIELD.id.symbolize}}] = self.{{CRECTO_PRIMARY_KEY_FIELD.id}} unless self.{{CRECTO_PRIMARY_KEY_FIELD.id}}.nil?
+          query_hash[{{CRECTO_PRIMARY_KEY_FIELD.id.stringify}}] = self.{{CRECTO_PRIMARY_KEY_FIELD.id}} unless self.{{CRECTO_PRIMARY_KEY_FIELD.id}}.nil?
         {% end %}
 
         query_hash
       end
 
-      def update_from_hash(hash : Hash(String, DbValue))
+      def update_from_hash(hash)
         {% unless CRECTO_FIELDS.empty? %}
           hash.each do |key, value|
             case key.to_s
@@ -273,6 +240,8 @@ module Crecto
                   begin
                     @{{field[:name].id}} = Time.parse!(value, "%F %T %z")
                   end
+                {% else %}
+                  @{{field[:name].id}} = value
                 {% end %}
               end
             {% end %}
@@ -288,16 +257,22 @@ module Crecto
         {% end %}
       end
 
-      def update_primary_key(val)
-        self.{{CRECTO_PRIMARY_KEY_FIELD.id}} = val
+      {% if CRECTO_USE_PRIMARY_KEY %}
+      def {{CRECTO_PRIMARY_KEY_FIELD.id }}
+        @{{CRECTO_PRIMARY_KEY_FIELD.id}}.not_nil!
       end
 
-      def updated_at_value
-        self.{{CRECTO_UPDATED_AT_FIELD.id}}
+      def {{CRECTO_PRIMARY_KEY_FIELD.id }}=(val)
+        @{{CRECTO_PRIMARY_KEY_FIELD.id}} = val
+      end
+      {% end %}
+
+      def updated_at
+        @{{CRECTO_UPDATED_AT_FIELD.id}}
       end
 
-      def created_at_value
-        self.{{CRECTO_CREATED_AT_FIELD.id}}
+      def created_at
+        @{{CRECTO_CREATED_AT_FIELD.id}}
       end
 
       def updated_at_to_now
@@ -324,9 +299,9 @@ module Crecto
         cast(attributes.to_h, whitelist.to_a)
       end
 
-      def cast(attributes : Hash(Symbol, T), whitelist : Array(Symbol) = attributes.keys) forall T
+      def cast(attributes : Hash(String, T), whitelist : Array(String | Symbol) = attributes.keys) forall T
         {% if CRECTO_FIELDS.size > 0 %}
-          cast_attributes = {} of Symbol => Union({{ CRECTO_FIELDS.map { |field| field[:type].id }.splat }})
+          cast_attributes = {} of String => Union({{ CRECTO_FIELDS.map { |field| field[:type].id }.splat }})
 
           attributes.each do |key, value|
             cast_attributes[key] = value

--- a/src/crecto/schema/associations.cr
+++ b/src/crecto/schema/associations.cr
@@ -3,25 +3,29 @@ module Crecto
     module Associations
       macro setup_associations
         # :nodoc:
-        CRECTO_ASSOCIATIONS = Array(NamedTuple(association_type: Symbol,
-          key: Symbol,
-          this_klass: Crecto::Model.class,
-          klass: Crecto::Model.class,
-          foreign_key: Symbol,
-          foreign_key_value: Proc(Crecto::Model, PkeyValue),
-          set_association: Proc(Crecto::Model, (Array(Crecto::Model) | Crecto::Model), Nil),
-          through: Symbol?)).new
+        CRECTO_ASSOCIATIONS = Array(
+          NamedTuple(
+            association_type: String,
+            key: String,
+            this_klass: Crecto::Model.class,
+            klass: Crecto::Model.class,
+            foreign_key: String,
+            foreign_key_value: Proc(Crecto::Model, PkeyValue),
+            set_association: Proc(Crecto::Model, (Array(Crecto::Model) | Crecto::Model), Nil),
+            through: String?
+          )
+        ).new
 
         # Get the Class for the assocation name
         # i.e. :posts => Post
-        def self.klass_for_association(association : Symbol)
-          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association && a[:this_klass] == self}.first[:klass]
+        def self.klass_for_association(association : String | Symbol)
+          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association.to_s && a[:this_klass] == self}.first[:klass]
         end
 
         # Get the foreign key for the association
         # i.e. :posts => :user_id
-        def self.foreign_key_for_association(association : Symbol) : Symbol?
-          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association && a[:this_klass] == self}.first[:foreign_key]
+        def self.foreign_key_for_association(association : String | Symbol) : String?
+          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association.to_s && a[:this_klass] == self}.first[:foreign_key]
         end
 
         def self.foreign_key_for_association(klass : Crecto::Model.class)
@@ -30,26 +34,26 @@ module Crecto
 
         # Get the foreign key value from the relation object
         # i.e. :posts, post => post.user_id
-        def self.foreign_key_value_for_association(association : Symbol, item)
-          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association && a[:this_klass] == self}.first[:foreign_key_value].call(item).as(PkeyValue)
+        def self.foreign_key_value_for_association(association : String | Symbol, item)
+          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association.to_s && a[:this_klass] == self}.first[:foreign_key_value].call(item).as(PkeyValue)
         end
 
         # Set the value for the association
         # i.e. :posts, user, [posts] => user.posts = [posts]
-        def self.set_value_for_association(association : Symbol, item, items)
-          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association && a[:this_klass] == self}.first[:set_association].call(item, items)
+        def self.set_value_for_association(association : String | Symbol, item, items)
+          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association.to_s && a[:this_klass] == self}.first[:set_association].call(item, items)
         end
 
         # Get the association type for the association
         # i.e. :posts => :has_many
-        def self.association_type_for_association(association : Symbol)
-          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association && a[:this_klass] == self}.first[:association_type]
+        def self.association_type_for_association(association : String | Symbol)
+          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association.to_s && a[:this_klass] == self}.first[:association_type]
         end
 
         # Get the through association symbol
         # i.e. :posts => :user_posts (if has_many through)
-        def self.through_key_for_association(association : Symbol) : Symbol?
-          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association && a[:this_klass] == self}.first[:through]
+        def self.through_key_for_association(association : String | Symbol) : String?
+          CRECTO_ASSOCIATIONS.select{|a| a[:key] == association.to_s && a[:this_klass] == self}.first[:through]
         end
       end
     end

--- a/src/crecto/schema/belongs_to.cr
+++ b/src/crecto/schema/belongs_to.cr
@@ -4,48 +4,56 @@ module Crecto
       # :nodoc:
       CRECTO_VALID_BELONGS_TO_OPTIONS = [:foreign_key]
 
-      macro belongs_to(association_name, klass, **opts)
+      macro belongs_to(association, **opts)
+        #
+        # BELONGS TO: {{ @type.id }}
+        #
         {% unless @type.has_constant? "CRECTO_ASSOCIATIONS" %}
           Crecto::Schema::Associations.setup_associations
         {% end %}
 
-        @{{association_name.id}} : {{klass}}?
+        {%
+          field_name = association.var
+          field_type = association.type
+        %}
 
-        def {{association_name.id}}? : {{klass}}?
-          @{{association_name.id}}
+        @{{field_name.id}} : {{field_type}}?
+
+        def {{field_name.id}}? : {{field_type}}?
+          @{{field_name.id}}
         end
 
-        def {{association_name.id}} : {{klass}}
-          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' is not loaded or is nil. Use `{{association_name.id}}?' if the association is nilable.")
+        def {{field_name.id}} : {{field_type}}
+          {{field_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{field_name.id}}' is not loaded or is nil. Use `{{field_name.id}}?' if the association is nilable.")
         end
 
 
         {%
-          foreign_key = klass.id.stringify.split(":")[-1].id.stringify.underscore.downcase + "_id"
+          foreign_key = field_type.id.stringify.split(":")[-1].id.stringify.underscore.downcase + "_id"
           foreign_key = opts[:foreign_key] if opts[:foreign_key]
         %}
 
-        {% unless CRECTO_FIELDS.select { |f| f[:name] == foreign_key.id.symbolize }.size > 0 %}
-          field {{foreign_key.id.symbolize}}, PkeyValue
+        {% unless CRECTO_FIELDS.select { |f| f[:name] == foreign_key.id.stringify }.size > 0 %}
+          field {{foreign_key.id}} : PkeyValue
         {% end %}
 
-        def {{association_name.id}}=(val : {{klass}}?)
-          @{{association_name.id}} = val
+        def {{field_name.id}}=(val : {{field_type}}?)
+          @{{field_name.id}} = val
           return if val.nil?
           @{{foreign_key.id}} = val.pkey_value.as(PkeyValue)
         end
 
         CRECTO_ASSOCIATIONS.push({
-          association_type: :belongs_to,
-          key: {{association_name}},
+          association_type: "belongs_to",
+          key: {{field_name.id.stringify}},
           this_klass: {{@type}},
-          klass: {{klass}},
-          foreign_key: {{foreign_key.id.symbolize}},
+          klass: {{field_type}},
+          foreign_key: {{foreign_key.id.stringify}},
           foreign_key_value: ->(item : Crecto::Model){
             item.as({{@type}}).{{foreign_key.id}}.as(PkeyValue)
           },
           set_association: ->(self_item : Crecto::Model, items : Array(Crecto::Model) | Crecto::Model){
-            self_item.as({{@type}}).{{association_name.id}} = items.as(Array(Crecto::Model))[0].as({{klass}});nil
+            self_item.as({{@type}}).{{field_name.id}} = items.as(Array(Crecto::Model))[0].as({{field_type}});nil
           },
           through: nil
         })

--- a/src/crecto/schema/has_one.cr
+++ b/src/crecto/schema/has_one.cr
@@ -4,21 +4,25 @@ module Crecto
     module HasOne
       VALID_HAS_ONE_OPTIONS = [:foreign_key]
 
-      macro has_one(association_name, klass, **opts)
+      macro has_one(association, **opts)
         {% unless @type.has_constant? "CRECTO_ASSOCIATIONS" %}
           Crecto::Schema::Associations.setup_associations
         {% end %}
 
-        @{{association_name.id}} : {{klass}}?
+        {%
+          field_name = association.var
+          field_type = association.type
+        %}
 
-        def {{association_name.id}}? : {{klass}}?
-          @{{association_name.id}}
+        @{{field_name.id}} : {{field_type}}?
+
+        def {{field_name.id}}? : {{field_type}}?
+          @{{field_name.id}}
         end
 
-        def {{association_name.id}} : {{klass}}
-          {{association_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{association_name.id}}' is not loaded or is nil. Use `{{association_name.id}}?' if the association is nilable.")
+        def {{field_name.id}} : {{field_type}}
+          {{field_name.id}}? || raise Crecto::AssociationNotLoaded.new("Association `{{field_name.id}}' is not loaded or is nil. Use `{{field_name.id}}?' if the association is nilable.")
         end
-
 
         {%
           foreign_key = @type.id.stringify.split(":")[-1].id.stringify.underscore.downcase + "_id"
@@ -28,32 +32,32 @@ module Crecto
         {% on_replace = opts[:dependent] || opts[:on_replace] %}
 
         {% if on_replace && on_replace == :destroy %}
-          self.add_destroy_association({{association_name.id.symbolize}})
+          self.add_destroy_association({{field_name.id.symbolize}})
         {% end %}
 
 
         {% if on_replace && on_replace == :nullify %}
-          self.add_nullify_association({{association_name.id.symbolize}})
+          self.add_nullify_association({{field_name.id.symbolize}})
         {% end %}
 
-        def {{association_name.id}}=(val : {{klass}}?)
-          @{{association_name.id}} = val
+        def {{field_name.id}}=(val : {{field_type}}?)
+          @{{field_name.id}} = val
           return if val.nil?
           @{{foreign_key.id}} = val.pkey_value.as(PkeyValue)
         end
 
 
         CRECTO_ASSOCIATIONS.push({
-          association_type: :has_one,
-          key: {{association_name}},
+          association_type: "has_one",
+          key: {{field_name.id.stringify}},
           this_klass: {{@type}},
-          klass: {{klass}},
-          foreign_key: {{foreign_key.id.symbolize}},
+          klass: {{field_type}},
+          foreign_key: {{foreign_key.id.stringify}},
           foreign_key_value: ->(item : Crecto::Model) {
-            item.as({{klass}}).{{foreign_key.id}}.as(PkeyValue)
+            item.as({{field_type}}).{{foreign_key.id}}.as(PkeyValue)
           },
           set_association: ->(self_item : Crecto::Model, item: Array(Crecto::Model) | Crecto::Model) {
-            self_item.as({{@type}}).{{association_name.id}} = item.as({{klass}})
+            self_item.as({{@type}}).{{field_name.id}} = item.as({{field_type}})
             nil
           },
           through: nil

--- a/src/types.cr
+++ b/src/types.cr
@@ -7,6 +7,6 @@ alias ArrayDbValue = Array(Bool) | Array(Float32) | Array(Float64) | Array(Int64
 # alias for String | Int32 | Int64 | Nil
 alias PkeyValue = String | Int8 | Int16 | Int32 | Int64 | Nil
 # :nodoc:
-alias WhereType = Hash(Symbol, PkeyValue) | Hash(Symbol, DbValue) | Hash(Symbol, Array(DbValue)) | Hash(Symbol, Array(PkeyValue)) | Hash(Symbol, Array(Int32)) | Hash(Symbol, Array(Int64)) | Hash(Symbol, Array(String)) | Hash(Symbol, Int32 | String) | Hash(Symbol, Int64 | String) | Hash(Symbol, Int32) | Hash(Symbol, Int64) | Hash(Symbol, Nil) | Hash(Symbol, String) | Hash(Symbol, Int32 | Int64 | String) | Hash(Symbol, Int32 | Int64 | String | Nil) | NamedTuple(clause: String, params: Array(DbValue | PkeyValue))
+alias WhereType = Hash(String, PkeyValue) | Hash(String, DbValue) | Hash(String, Array(DbValue)) | Hash(String, Array(PkeyValue)) | Hash(String, Array(Int32)) | Hash(String, Array(Int64)) | Hash(String, Array(String)) | Hash(String, Int32 | String) | Hash(String, Int64 | String) | Hash(String, Int32) | Hash(String, Int64) | Hash(String, Nil) | Hash(String, String) | Hash(String, Int32 | Int64 | String) | Hash(String, Int32 | Int64 | String | Nil) | NamedTuple(clause: String, params: Array(DbValue | PkeyValue))
 # :nodoc:
 alias Json = JSON::Any


### PR DESCRIPTION
This is the start of a major overhaul for Crecto. Dependent on how @fridgerator feels about it, this may end up becoming my own forked project.

First of all, I removed most all references to `Symbol` as an input and storage type. Since symbols can't be created at runtime like they can in Ruby (and presumably Elixir) this makes the most sense. Everything that previously accepted a Symbol is still free to do so.

Macros such as `field`, `has_one`, `has_many`, and `belongs_to` have been modified to use type notation. This means that instead of `field foo, Bar` you now do `field foo : Bar`, as it's more up to snuff with Crystal conventions.

Lastly, `enum_field` has been removed and `converter` has been added as an argument for `field`. Enums can be handled now using the builtin `Crecto::EnumStringConverter` which uses `to_s`, and `Crecto::EnumIntConverter` which uses the Enum's value.